### PR TITLE
v1.2.1 better error handling and metadata for DataEntities

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
   "name": "kafka",
   "description": "Kafka reader and writer support.",
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,10 +1,10 @@
 {
   "name": "asset",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@terascope/job-components": "^0.9.0",
+    "@terascope/job-components": "^0.11.0",
     "bluebird": "^3.5.3",
     "lodash": "^4.17.11"
   },

--- a/asset/teraslice_kafka_reader/index.js
+++ b/asset/teraslice_kafka_reader/index.js
@@ -19,6 +19,9 @@ function newReader(context, opConfig) {
     const events = context.foundation.getEventEmitter();
     const retryStart = 5000;
     const retryLimit = 10000;
+
+    const badRecordAction = opConfig.bad_record_action;
+
     let { logger } = context;
     // We keep track of consecutive 0 record slices in order to defend against
     // the consumer failing to read data.
@@ -231,8 +234,13 @@ function newReader(context, opConfig) {
                         metadata
                     );
                 } catch (err) {
-                    logger.error('Bad record', message);
-                    logger.error(err);
+                    if (badRecordAction === 'log') {
+                        logger.error('Bad record', message);
+                        logger.error(err);
+                    } else if (badRecordAction === 'throw') {
+                        throw err;
+                    }
+
                     return null;
                 }
             }
@@ -516,6 +524,11 @@ function schema() {
             doc: 'Number of consecutive zero record slices allowed before the consumer will automatically re-initialize. This is to guard against bugs in librdkafka.',
             default: -1,
             format: Number
+        },
+        bad_record_action: {
+            doc: 'How to handle bad records, defaults to doing nothing',
+            default: 'none',
+            format: ['none', 'throw', 'log']
         }
     };
 }

--- a/asset/yarn.lock
+++ b/asset/yarn.lock
@@ -2,15 +2,17 @@
 # yarn lockfile v1
 
 
-"@terascope/job-components@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.9.0.tgz#cb9290c686ccc03a915582feb78a6bfc25c9aa10"
-  integrity sha512-jilSIdM+0rVlYbnM2r5Ev6Z14iYoxdUDwOZpcWfHaZIEHds0/qvTbOI7Z9nMyJNnsL0d5Rwaec6b8RAJSj4c9g==
+"@terascope/job-components@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.11.0.tgz#d726fe0c436fcf4b2393220213b93a17c126317a"
+  integrity sha512-nnoDtLjd9+VVX75Nr+z8p7CbWkzgwgMax/9Q9rjxc5T00kKN80AERc0httONeRgPm5lu1UAYG6LMU3hhDOQV/g==
   dependencies:
     "@terascope/queue" "^1.1.4"
     convict "^4.4.0"
     datemath-parser "^1.0.6"
     debug "^4.1.0"
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
     lodash.clonedeep "^4.5.0"
     uuid "^3.3.2"
 
@@ -60,12 +62,29 @@ depd@1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  dependencies:
+    isobject "^3.0.1"
+
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
 json5@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
 lodash.clonedeep@4.5.0, lodash.clonedeep@^4.5.0:
   version "4.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-assets",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "teraslice asset for kafka operations",
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,15 +951,6 @@ eslint-config-airbnb-base@^13.1.0:
     object.assign "^4.1.0"
     object.entries "^1.0.4"
 
-eslint-config-airbnb@^17.0.0:
-  version "17.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz#3964ed4bc198240315ff52030bf8636f42bc4732"
-  integrity sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==
-  dependencies:
-    eslint-config-airbnb-base "^13.1.0"
-    object.assign "^4.1.0"
-    object.entries "^1.0.4"
-
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -976,7 +967,7 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-import@^2.13.0:
+eslint-plugin-import@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"
   integrity sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==
@@ -991,11 +982,6 @@ eslint-plugin-import@^2.13.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
-
-eslint-plugin-jasmine@^2.10.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.10.1.tgz#5733b709e751f4bc40e31e1c16989bd2cdfbec97"
-  integrity sha1-VzO3CedR9LxA4x4cFpib0s377Jc=
 
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
- better error handling when creating DataEntities
- store more metadata in the `DataEntity`
- update `job-components`
- add option `bad_record_action` to reader. This can set to one of the following:
    - `none` - (default) do nothing with the record
    - `log` - log the record and error
    - `throw` - throw the original error and fail the slice