### PR TITLE
v2.1.7 fix commit.offset handler

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "2.1.6"
+    "version": "2.1.7"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-assets",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",

--- a/asset/src/_kafka_clients/base-client.ts
+++ b/asset/src/_kafka_clients/base-client.ts
@@ -122,12 +122,12 @@ export default class BaseClient<T extends kafka.Client> {
 
             if (err && isError(err)) {
                 if (isOkayError(err, 'retryable')) {
-                    this._logger.warn(`kafka client warning for event "${event}"`, err);
+                    this._logger.warn(err, `kafka client warning for event "${event}"`);
                     return;
                 }
 
                 if (!isKafkaError(err) || !isOkayError(err, 'any')) {
-                    this._logger.error(`kafka client error for event "${event}"`, err);
+                    this._logger.error(err, `kafka client error for event "${event}"`);
                     return;
                 }
             }
@@ -265,7 +265,7 @@ export default class BaseClient<T extends kafka.Client> {
                 this._incBackOff();
                 await pDelay(this._backoff);
 
-                this._logger.warn(`got retryable kafka${actionStr}, will retry in ${this._backoff}ms`, err);
+                this._logger.warn(err, `got retryable kafka${actionStr}, will retry in ${this._backoff}ms`);
                 return this._try(fn, action, retries - 1);
             }
 

--- a/asset/src/_kafka_clients/consumer-client.ts
+++ b/asset/src/_kafka_clients/consumer-client.ts
@@ -347,11 +347,25 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
         });
 
         // @ts-ignore because the event doesn't exist in the type definitions
-        this._client.on('offset.commit', (offsets) => {
-            if (!offsets || !Array.isArray(offsets)) {
+        this._client.on('offset.commit', (_err, _offsets) => {
+            let err: Error|null = null;
+            let offsets: TopicPartition[] = [];
+            // the change the way this event is called
+            if (_offsets && Array.isArray(_offsets)) {
+                err = _err;
+                offsets = _offsets;
+            } else if (_err && Array.isArray(_err)) {
+                err = null;
+                offsets = _err;
+            }
+            // log error if we get one
+            if (err) this._logger.warn(err, 'offset commit error', { offsets });
+
+            if (!Array.isArray(offsets)) {
                 this._logger.trace('Invalid event data for offset.commit', offsets);
                 return;
             }
+
             offsets.forEach((offset: TopicPartition) => this._removePendingCommit(offset));
         });
     }

--- a/asset/src/_kafka_clients/consumer-client.ts
+++ b/asset/src/_kafka_clients/consumer-client.ts
@@ -335,7 +335,7 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
             try {
                 this._handleRebalance(err, assignments);
             } catch (err) {
-                this._logger.error('error handling rebalance', err);
+                this._logger.error(err, 'failure handling rebalance');
             }
         });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-asset-bundle",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "private": true,
     "scripts": {

--- a/test/base-client-spec.ts
+++ b/test/base-client-spec.ts
@@ -301,7 +301,7 @@ describe('Base Client (internal)', () => {
                 client._logOrEmit('test:log:warn')(error, 'hello');
 
                 expect(logger.warn).toHaveBeenCalledTimes(1);
-                expect(logger.warn).toHaveBeenCalledWith('kafka client warning for event "test:log:warn"', error);
+                expect(logger.warn).toHaveBeenCalledWith(error, 'kafka client warning for event "test:log:warn"');
             });
 
             it('should log to error when given a fatal error', () => {
@@ -311,7 +311,7 @@ describe('Base Client (internal)', () => {
                 client._logOrEmit('test:log:error')(error, 'hello');
 
                 expect(logger.error).toHaveBeenCalledTimes(1);
-                expect(logger.error).toHaveBeenCalledWith('kafka client error for event "test:log:error"', error);
+                expect(logger.error).toHaveBeenCalledWith(error, 'kafka client error for event "test:log:error"');
             });
         });
     });


### PR DESCRIPTION
`node-rdkafka` introduced a [breaking change](https://github.com/Blizzard/node-rdkafka/commit/575c791738aaf1e5053fb86bb6731a0883edd949#diff-00945053400287f301a6b6a43c5f69ad) to the offset.commit callback. I fixed it so its backwards and forwards compatible.

@erik-stephens this should fix some of the partition behind log messages we've seeing.