### PR TITLE
v2.2.0 - Update node-rdkafka and add use_commit_async option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ yarn global add teraslice-cli
 teraslice-cli asset deploy ...
 ```
 
+
 **IMPORTANT:** Additionally make sure have installed the required [connectors](#connectors).
 
 ## Connectors
-
 ### Kafka Connector
 
 > Terafoundation connector for Kafka producer and consumer clients.
@@ -67,6 +67,7 @@ The terafoundation level configuration is as follows:
 |     **ssl_key_password**     |        `String`        |         -          |                           Private key passphrase                           |
 
 When using this connector in code, this connector exposes two different client implementations. One for producers `type: producer` and one for consumers `type: consumer`.
+
 
 | Name                | Description                                                                                                                             | Default   | Required |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------- |
@@ -208,6 +209,7 @@ terafoundation:
 |      **rollback_on_failure**      |                                   `Boolean`                                   |   `false`    |                                                             Controls whether the consumer state is rolled back on failure. This will protect against data loss, however this can have an unintended side effect of blocking the job from moving if failures are minor and persistent. **NOTE:** This currently defaults to `false` due to the side effects of the behavior, at some point in the future it is expected this will default to `true`.                                                              |
 |             **size**              |                                   `Number`                                    |   `10000`    |                                                                                                                                                                                                                         How many records to read before a slice is considered complete.                                                                                                                                                                                                                          |
 |             **topic**             |                                   `String`                                    |      -       |                                                                                                                                                                                                                                        Name of the Kafka topic to process                                                                                                                                                                                                                                        |
+|        **use_commit_sync**        |                                   `Boolean`                                   |   `false`    |                                                                                                                                                                                                                            Use commit sync instead of async (usually not recommended)                                                                                                                                                                                                                            |
 |             **wait**              |                                   `Number`                                    |   `30000`    |                                                                                                                                                                                                              How long to wait for a full chunk of data to be available. Specified in milliseconds.                                                                                                                                                                                                               |
 
 **Example Job Config:**
@@ -300,7 +302,6 @@ Run the kafka tests
 - `kafka` - A running instance of kafka
 
 **Environment:**
-
 - `KAFKA_BROKERS` - Defaults to `localhost:9091`
 
 ```bash

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "2.1.7"
+    "version": "2.2.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -5,7 +5,7 @@
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",
     "dependencies": {
-        "@terascope/job-components": "^0.20.8",
+        "@terascope/job-components": "^0.21.1",
         "lodash.once": "^4.1.1"
     },
     "devDependencies": {},

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-assets",
-    "version": "2.1.7",
+    "version": "2.2.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",

--- a/asset/src/_kafka_clients/base-client.ts
+++ b/asset/src/_kafka_clients/base-client.ts
@@ -301,7 +301,7 @@ export default class BaseClient<T extends kafka.Client> {
 }
 
 // get random number inclusive
-function getRandom(min: number, max: number) {
+export function getRandom(min: number, max: number) {
     return Math.random() * (max - min + 1) + min; // The maximum is inclusive and the minimum is inclusive
 }
 

--- a/asset/src/kafka_reader/fetcher.ts
+++ b/asset/src/kafka_reader/fetcher.ts
@@ -65,7 +65,7 @@ export default class KafkaFetcher extends Fetcher<KafkaReaderConfig> {
     }
 
     async onSliceFinalizing() {
-        await this.consumer.commit();
+        await this.consumer.commit(this.opConfig.use_commit_sync);
     }
 
     // TODO we should handle slice retries differently now that we have the dead letter queue

--- a/asset/src/kafka_reader/interfaces.ts
+++ b/asset/src/kafka_reader/interfaces.ts
@@ -37,6 +37,11 @@ export interface KafkaReaderConfig extends OpConfig {
     interval: number;
 
     /**
+     * Use commit sync instead of async (usually not recommended)
+    */
+    use_commit_sync: boolean;
+
+    /**
      Controls whether the consumer state is rolled back on failure.
      This will protect against data loss, however this can have an unintended side effect
      of blocking the job from moving if failures are minor and persistent.

--- a/asset/src/kafka_reader/schema.ts
+++ b/asset/src/kafka_reader/schema.ts
@@ -48,6 +48,11 @@ export default class Schema extends ConvictSchema<KafkaReaderConfig> {
                 default: 'default',
                 format: 'required_String'
             },
+            use_commit_sync: {
+                doc: 'Use commit sync instead of async (usually not recommended)',
+                default: false,
+                format: Boolean
+            },
             rollback_on_failure: {
                 doc: [
                     'Controls whether the consumer state is rolled back on failure.',

--- a/asset/yarn.lock
+++ b/asset/yarn.lock
@@ -2,26 +2,26 @@
 # yarn lockfile v1
 
 
-"@terascope/job-components@^0.20.8":
-  version "0.20.8"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.20.8.tgz#415b68913d136f02356e5f604c520c3899f18be0"
-  integrity sha512-8Hw1A54o1imObBnSeZXuDfZ3qKFhCmS0LFYTYorupF1upR5Kkca69UU7knDASx08MjR3M18EDhxmbMc2MJ9Jtw==
+"@terascope/job-components@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.21.1.tgz#f3cb3d6d795650835bf7c7519a01a984797b2237"
+  integrity sha512-HCmUvidUUfhCf1SJEFpWrg59EMbCvK2riVA8v/q/ha2eJEJK/9OHwygUPJVSVINS6qGKdFXTQMBaELOEff+Igw==
   dependencies:
     "@terascope/queue" "^1.1.6"
-    "@terascope/utils" "^0.14.1"
+    "@terascope/utils" "^0.16.1"
     convict "^4.4.1"
     datemath-parser "^1.0.6"
-    uuid "^3.3.2"
+    uuid "^3.3.3"
 
 "@terascope/queue@^1.1.6":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@terascope/queue/-/queue-1.1.6.tgz#763d035cf31d2e1fd819ae827274f50874016708"
   integrity sha512-TmLOLh49UVdksjwAUzOO6lqOQMwJIW0pHsXKibcdfzAcUgwXL3JH6BjO2l1u5njQeHjoj1SOyBk6aU1/fHd0PQ==
 
-"@terascope/utils@^0.14.1":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.14.1.tgz#8b24dcdfca5be2e96bf5edeb0d51be156e661b3f"
-  integrity sha512-8XSrOXCY18AC/EsL+ebC2NFGDinIDcjz1BQWFHoXifaZGCPG3gqkodrz/O0QgF9plkrNVp69oZ4bzbITlNtUeg==
+"@terascope/utils@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.16.1.tgz#cd68c760e9c5d6fff4c199d2c614be42c3d6991b"
+  integrity sha512-DNbeD5I0vZ+tLFZRTKE4LyJGQRwrFMczJwlKLJihhK9N/3maToAvqjcOqnJgaKbSGrp4e9zb3sxCmVoRl1YDeQ==
   dependencies:
     debug "^4.1.1"
     is-plain-object "^3.0.0"
@@ -135,10 +135,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-uuid@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+uuid@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
 validator@10.8.0:
   version "10.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-asset-bundle",
-    "version": "2.1.7",
+    "version": "2.2.0",
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "private": true,
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
         "markdown-table": "^1.1.3",
         "markdown-toc": "^1.2.0",
         "rimraf": "^3.0.0",
-        "teraslice-test-harness": "^0.8.2",
+        "teraslice-test-harness": "^0.8.3",
         "ts-jest": "^24.0.2",
         "ts-node": "^8.3.0",
         "tslint": "^5.18.0",
         "tslint-config-airbnb": "^5.11.1",
         "typescript": "^3.5.3",
-        "uuid": "^3.3.2"
+        "uuid": "^3.3.3"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -23,7 +23,7 @@
     "author": "Terascope, LLC <info@terascope.io>",
     "license": "MIT",
     "dependencies": {
-        "node-rdkafka": "^2.7.1-2"
+        "node-rdkafka": "~2.7.1-2"
     },
     "devDependencies": {
         "@terascope/job-components": "^0.21.1",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation_kafka_connector",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "publishConfig": {
         "access": "public"
@@ -23,10 +23,10 @@
     "author": "Terascope, LLC <info@terascope.io>",
     "license": "MIT",
     "dependencies": {
-        "node-rdkafka": "2.7.0"
+        "node-rdkafka": "^2.7.1-2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.20.8",
+        "@terascope/job-components": "^0.21.1",
         "@types/convict": "^4.2.1",
         "convict": "^4.4.1"
     },

--- a/packages/terafoundation_kafka_connector/src/index.ts
+++ b/packages/terafoundation_kafka_connector/src/index.ts
@@ -28,7 +28,11 @@ import {
 class KafakConnector {
     create(config: KafkaConnectorConfig, logger: Logger, settings: KafkaConsumerSettings): KafkaConsumerResult;
     create(config: KafkaConnectorConfig, logger: Logger, settings: KafkaProducerSettings): KafkaProducerResult;
-    create(config: KafkaConnectorConfig, logger: Logger, settings: KafkaConsumerSettings|KafkaProducerSettings): KafkaConsumerResult|KafkaProducerResult {
+    create(
+        config: KafkaConnectorConfig,
+        logger: Logger,
+        settings: KafkaConsumerSettings|KafkaProducerSettings
+    ): KafkaConsumerResult|KafkaProducerResult {
         const clientType = getClientType(settings.options && settings.options.type);
 
         if (isConsumerSettings(settings)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,7 +342,7 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@terascope/job-components@^0.20.7", "@terascope/job-components@^0.20.8":
+"@terascope/job-components@^0.20.7":
   version "0.20.8"
   resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.20.8.tgz#415b68913d136f02356e5f604c520c3899f18be0"
   integrity sha512-8Hw1A54o1imObBnSeZXuDfZ3qKFhCmS0LFYTYorupF1upR5Kkca69UU7knDASx08MjR3M18EDhxmbMc2MJ9Jtw==
@@ -352,6 +352,17 @@
     convict "^4.4.1"
     datemath-parser "^1.0.6"
     uuid "^3.3.2"
+
+"@terascope/job-components@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.21.1.tgz#f3cb3d6d795650835bf7c7519a01a984797b2237"
+  integrity sha512-HCmUvidUUfhCf1SJEFpWrg59EMbCvK2riVA8v/q/ha2eJEJK/9OHwygUPJVSVINS6qGKdFXTQMBaELOEff+Igw==
+  dependencies:
+    "@terascope/queue" "^1.1.6"
+    "@terascope/utils" "^0.16.1"
+    convict "^4.4.1"
+    datemath-parser "^1.0.6"
+    uuid "^3.3.3"
 
 "@terascope/queue@^1.1.6":
   version "1.1.6"
@@ -371,6 +382,18 @@
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.14.1.tgz#8b24dcdfca5be2e96bf5edeb0d51be156e661b3f"
   integrity sha512-8XSrOXCY18AC/EsL+ebC2NFGDinIDcjz1BQWFHoXifaZGCPG3gqkodrz/O0QgF9plkrNVp69oZ4bzbITlNtUeg==
+  dependencies:
+    debug "^4.1.1"
+    is-plain-object "^3.0.0"
+    kind-of "^6.0.2"
+    lodash.clonedeep "^4.5.0"
+    lodash.get "^4.4.2"
+    lodash.set "^4.3.2"
+
+"@terascope/utils@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.16.1.tgz#cd68c760e9c5d6fff4c199d2c614be42c3d6991b"
+  integrity sha512-DNbeD5I0vZ+tLFZRTKE4LyJGQRwrFMczJwlKLJihhK9N/3maToAvqjcOqnJgaKbSGrp4e9zb3sxCmVoRl1YDeQ==
   dependencies:
     debug "^4.1.1"
     is-plain-object "^3.0.0"
@@ -2877,7 +2900,7 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.10.0, nan@^2.11.1, nan@^2.12.1:
+nan@^2.10.0, nan@^2.12.1, nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -2965,13 +2988,13 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-rdkafka@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.7.0.tgz#3e96fc3dd31f28a7c4fea6277f943a88da84edc2"
-  integrity sha512-pSO60jT0AC0eEzXlRxUoNpEp7nCdtglHMBJ2r5lP0y+TqXDAUrV1it1ZtXfi4yeKShksLdRfMI/jeLXWXMMpLA==
+node-rdkafka@^2.7.1-2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.7.1-2.tgz#686626417af095fd9653d2c6e053f214408da00b"
+  integrity sha512-sSpKsAGVeIn5l7Z3wNAtIP122MPK5rqgzNuRIGGwo6Z73bEoRgbjJmLhHwS8zx/lCCFYZ2YGKEnG48Ztr73XDA==
   dependencies:
     bindings "^1.3.1"
-    nan "^2.11.1"
+    nan "^2.14.0"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -4201,6 +4224,11 @@ uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,18 +342,7 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@terascope/job-components@^0.20.7":
-  version "0.20.8"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.20.8.tgz#415b68913d136f02356e5f604c520c3899f18be0"
-  integrity sha512-8Hw1A54o1imObBnSeZXuDfZ3qKFhCmS0LFYTYorupF1upR5Kkca69UU7knDASx08MjR3M18EDhxmbMc2MJ9Jtw==
-  dependencies:
-    "@terascope/queue" "^1.1.6"
-    "@terascope/utils" "^0.14.1"
-    convict "^4.4.1"
-    datemath-parser "^1.0.6"
-    uuid "^3.3.2"
-
-"@terascope/job-components@^0.21.1":
+"@terascope/job-components@^0.21.0", "@terascope/job-components@^0.21.1":
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.21.1.tgz#f3cb3d6d795650835bf7c7519a01a984797b2237"
   integrity sha512-HCmUvidUUfhCf1SJEFpWrg59EMbCvK2riVA8v/q/ha2eJEJK/9OHwygUPJVSVINS6qGKdFXTQMBaELOEff+Igw==
@@ -369,26 +358,14 @@
   resolved "https://registry.yarnpkg.com/@terascope/queue/-/queue-1.1.6.tgz#763d035cf31d2e1fd819ae827274f50874016708"
   integrity sha512-TmLOLh49UVdksjwAUzOO6lqOQMwJIW0pHsXKibcdfzAcUgwXL3JH6BjO2l1u5njQeHjoj1SOyBk6aU1/fHd0PQ==
 
-"@terascope/teraslice-op-test-harness@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@terascope/teraslice-op-test-harness/-/teraslice-op-test-harness-1.7.1.tgz#4c216dc6a38dbf61bcb504d7c1300e615ec51421"
-  integrity sha512-24YeEK46LYv/bt+373LkSY+u8j1NQUJg07wOVVPpSsbhV6JWSH+E0i9+jbcUJpCjE9JJBxBfPwonbXxXOlredw==
+"@terascope/teraslice-op-test-harness@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@terascope/teraslice-op-test-harness/-/teraslice-op-test-harness-1.7.2.tgz#35f534d8c981b3409a6d2cba9cc31b801e47dd59"
+  integrity sha512-XKTT4gooTZYggpsz1yp0o6ELWvTtmJXHRzM8KBoq95nCXscJs7Jupyg2nTpeEetC3EnebWvS4az4CJk+IibYgw==
   dependencies:
-    "@terascope/job-components" "^0.20.7"
+    "@terascope/job-components" "^0.21.0"
     bluebird "^3.5.5"
     lodash "^4.17.11"
-
-"@terascope/utils@^0.14.1":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.14.1.tgz#8b24dcdfca5be2e96bf5edeb0d51be156e661b3f"
-  integrity sha512-8XSrOXCY18AC/EsL+ebC2NFGDinIDcjz1BQWFHoXifaZGCPG3gqkodrz/O0QgF9plkrNVp69oZ4bzbITlNtUeg==
-  dependencies:
-    debug "^4.1.1"
-    is-plain-object "^3.0.0"
-    kind-of "^6.0.2"
-    lodash.clonedeep "^4.5.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
 
 "@terascope/utils@^0.16.1":
   version "0.16.1"
@@ -3915,13 +3892,13 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-teraslice-test-harness@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/teraslice-test-harness/-/teraslice-test-harness-0.8.2.tgz#7d18cc9c18be643b149699e656ce35646ff5b25d"
-  integrity sha512-Ub1S+FjHHZ0BM5xJNY8Djd0tBplgZBZHZmCB1FeZF2lq0RDAYQps05pm7OZts/CfON/+DjmnAWo1hbAoGdxmMQ==
+teraslice-test-harness@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/teraslice-test-harness/-/teraslice-test-harness-0.8.3.tgz#6b3123aea590d25e9b3bda055a2395689507d166"
+  integrity sha512-T26A97PVIsQoUALv/b07f++3XqkgvhAIIE3thpC0HV4zL50GmrTgxOv301Mw8pWjk2jBqUVAkVdoKgw+jnOLvw==
   dependencies:
-    "@terascope/job-components" "^0.20.7"
-    "@terascope/teraslice-op-test-harness" "^1.7.1"
+    "@terascope/job-components" "^0.21.0"
+    "@terascope/teraslice-op-test-harness" "^1.7.2"
     lodash "^4.17.11"
 
 test-exclude@^5.2.3:


### PR DESCRIPTION
- Update `node-rdkafka` and bump connector `v0.5.0`
- Add `use_commit_sync` option to `kafka_reader` to test using commit async vs sync
