### PR TITLE
Add node@12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ addons:
     packages:
       - jq
 cache:
-  yarn: true
-  directories:
-    - "$HOME/.kafka-downloads"
+  npm: false
+  yarn: false
 before_install:
   # Install latest yarn
   - curl -o- -L https://yarnpkg.com/install.sh | bash
@@ -70,7 +69,6 @@ deploy:
     on:
       tags: true
       condition: $TRAVIS_OS_NAME = linux
-      node: '10'
   - provider: releases
     api_key: $GITHUB_TOKEN
     prerelease: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - export KAFKA_TMP="$HOME/.kafka-downloads"
   - mkdir -p "$KAFKA_HOME"
   - mkdir -p "$KAFKA_TMP"
-  - '[[ ! -f "$KAFKA_TMP/kafka.tgz" ]] && wget https://www.apache.org/dist/kafka/2.1.1/kafka_2.11-2.1.1.tgz -O "$KAFKA_TMP/kafka.tgz" || echo "* using cache"'
+  - '[[ ! -f "$KAFKA_TMP/kafka.tgz" ]] && wget https://www.apache.org/dist/kafka/2.3.1/kafka_2.11-2.3.1.tgz -O "$KAFKA_TMP/kafka.tgz" || echo "* using cache"'
   - tar xzf "$KAFKA_TMP/kafka.tgz" -C $KAFKA_HOME --strip-components 1
   # add bin to path for ease of use
   - export PATH="$KAFKA_HOME/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: bionic
 language: node_js
 node_js:
   - '10.16'
+  - '12.13'
 os:
   - linux
   - osx
@@ -47,11 +48,10 @@ before_install:
   - export FORCE_COLOR=1
   # Install teraslice-cli
   - yarn global add teraslice-cli
-
 install:
   - yarn
 script:
-    - yarn test:all
+  - yarn test:all
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - yarn lint:all
@@ -70,7 +70,7 @@ deploy:
     on:
       tags: true
       condition: $TRAVIS_OS_NAME = linux
-      node: '8'
+      node: '10'
   - provider: releases
     api_key: $GITHUB_TOKEN
     prerelease: true

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "2.4.0"
+    "version": "2.4.1"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-assets",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",

--- a/asset/src/_kafka_clients/base-client.ts
+++ b/asset/src/_kafka_clients/base-client.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import once from 'lodash.once';
 import { Logger, isError, pDelay } from '@terascope/job-components';
-import * as kafka from 'node-rdkafka';
+import * as kafka from '@terascope/node-rdkafka';
 import {
     isOkayError,
     wrapError,

--- a/asset/src/_kafka_clients/consumer-client.ts
+++ b/asset/src/_kafka_clients/consumer-client.ts
@@ -1,5 +1,5 @@
 
-import * as kafka from 'node-rdkafka';
+import * as kafka from '@terascope/node-rdkafka';
 import { pDelay } from '@terascope/job-components';
 import {
     wrapError,

--- a/asset/src/_kafka_clients/producer-client.ts
+++ b/asset/src/_kafka_clients/producer-client.ts
@@ -1,4 +1,4 @@
-import * as kafka from 'node-rdkafka';
+import * as kafka from '@terascope/node-rdkafka';
 import { ProduceMessage, ProducerClientConfig } from './interfaces';
 import { wrapError, AnyKafkaError } from '../_kafka_helpers';
 import BaseClient from './base-client';

--- a/asset/src/kafka_dead_letter/api.ts
+++ b/asset/src/kafka_dead_letter/api.ts
@@ -7,7 +7,7 @@ import {
     parseError,
     Collector,
 } from '@terascope/job-components';
-import * as kafka from 'node-rdkafka';
+import * as kafka from '@terascope/node-rdkafka';
 import { KafkaDeadLetterConfig } from './interfaces';
 import { ProducerClient, ProduceMessage } from '../_kafka_clients';
 

--- a/asset/src/kafka_reader/fetcher.ts
+++ b/asset/src/kafka_reader/fetcher.ts
@@ -5,7 +5,7 @@ import {
     ConnectionConfig,
     DataEntity
 } from '@terascope/job-components';
-import * as kafka from 'node-rdkafka';
+import * as kafka from '@terascope/node-rdkafka';
 import { KafkaReaderConfig } from './interfaces';
 import { ConsumerClient } from '../_kafka_clients';
 import {

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -7,7 +7,7 @@ import {
     getValidDate,
     isString,
 } from '@terascope/job-components';
-import * as kafka from 'node-rdkafka';
+import * as kafka from '@terascope/node-rdkafka';
 import { KafkaSenderConfig } from './interfaces';
 import { ProducerClient, ProduceMessage } from '../_kafka_clients';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-asset-bundle",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "private": true,
     "scripts": {

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation_kafka_connector",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "publishConfig": {
         "access": "public"
@@ -21,7 +21,7 @@
     "author": "Terascope, LLC <info@terascope.io>",
     "license": "MIT",
     "dependencies": {
-        "node-rdkafka": "~2.7.1-2"
+        "@terascope/node-rdkafka": "~2.7.3"
     },
     "devDependencies": {
         "@terascope/job-components": "^0.23.9",

--- a/packages/terafoundation_kafka_connector/src/index.ts
+++ b/packages/terafoundation_kafka_connector/src/index.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@terascope/job-components';
-import { KafkaConsumer, Producer } from 'node-rdkafka';
+import { KafkaConsumer, Producer } from '@terascope/node-rdkafka';
 import schema from './schema';
 import {
     KafkaConnectorConfig,

--- a/packages/terafoundation_kafka_connector/src/interfaces.ts
+++ b/packages/terafoundation_kafka_connector/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { KafkaConsumer, Producer } from 'node-rdkafka';
+import { KafkaConsumer, Producer } from '@terascope/node-rdkafka';
 
 export interface KafkaConnectorConfig {
     /** A list of brokers */

--- a/test/helpers/kafka-admin.ts
+++ b/test/helpers/kafka-admin.ts
@@ -1,5 +1,5 @@
 import { debugLogger, pDelay } from '@terascope/job-components';
-import { AdminClient, InternalAdminClient } from 'node-rdkafka';
+import { AdminClient, InternalAdminClient } from '@terascope/node-rdkafka';
 import { ERR_UNKNOWN_TOPIC_OR_PART } from '../../asset/src/_kafka_helpers/error-codes';
 import { kafkaBrokers } from './config';
 

--- a/test/helpers/kafka-data.ts
+++ b/test/helpers/kafka-data.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import uuidv4 from 'uuid/v4';
 import { debugLogger } from '@terascope/job-components';
-import * as kafka from 'node-rdkafka';
+import * as kafka from '@terascope/node-rdkafka';
 import { kafkaBrokers } from './config';
 import { ProducerClient, ConsumerClient } from '../../asset/src/_kafka_clients';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,6 +355,14 @@
     datemath-parser "^1.0.6"
     uuid "^3.3.3"
 
+"@terascope/node-rdkafka@~2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@terascope/node-rdkafka/-/node-rdkafka-2.7.3.tgz#fefcc3c2e7de48de3f4754edca024f21a93d60f6"
+  integrity sha512-9F9+MHmqpTF2CtQtV1Nd1MNgGBbnrNKrMERhalb+dleSP4Frizfb8P9qvCtayHWY+AwxNqrNWsE6BhpjmkFZRw==
+  dependencies:
+    bindings "^1.3.1"
+    nan "^2.14.0"
+
 "@terascope/queue@^1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@terascope/queue/-/queue-1.1.7.tgz#26cd3a42747ec802744f9b86c08034b0bbe07091"
@@ -3421,14 +3429,6 @@ node-pre-gyp@^0.12.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
-
-node-rdkafka@~2.7.1-2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.7.1-2.tgz#686626417af095fd9653d2c6e053f214408da00b"
-  integrity sha512-sSpKsAGVeIn5l7Z3wNAtIP122MPK5rqgzNuRIGGwo6Z73bEoRgbjJmLhHwS8zx/lCCFYZ2YGKEnG48Ztr73XDA==
-  dependencies:
-    bindings "^1.3.1"
-    nan "^2.14.0"
 
 nopt@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Adds support for node 12 by using [`@terascope/node-rdkafka`](https://github.com/terascope/node-rdkafka#why-does-this-fork-exists).