### PR TITLE
v2.4.2 - Fix wait issue

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "2.4.1"
+    "version": "2.4.2"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-assets",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",

--- a/asset/src/kafka_reader/fetcher.ts
+++ b/asset/src/kafka_reader/fetcher.ts
@@ -104,6 +104,9 @@ export default class KafkaFetcher extends Fetcher<KafkaReaderConfig> {
                 offset_commit_cb: true,
                 // Set the max.poll.interval.ms
                 'max.poll.interval.ms': this.opConfig.max_poll_interval,
+                // Enable partition EOF because node-rdkafka
+                // requires this work for consuming batches
+                'enable.partition.eof': true,
             },
             autoconnect: false
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-asset-bundle",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "private": true,
     "scripts": {

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation_kafka_connector",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "publishConfig": {
         "access": "public"
@@ -21,7 +21,7 @@
     "author": "Terascope, LLC <info@terascope.io>",
     "license": "MIT",
     "dependencies": {
-        "@terascope/node-rdkafka": "~2.7.3"
+        "@terascope/node-rdkafka": "~2.7.4"
     },
     "devDependencies": {
         "@terascope/job-components": "^0.23.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,10 +355,10 @@
     datemath-parser "^1.0.6"
     uuid "^3.3.3"
 
-"@terascope/node-rdkafka@~2.7.3":
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/@terascope/node-rdkafka/-/node-rdkafka-2.7.3.tgz#fefcc3c2e7de48de3f4754edca024f21a93d60f6"
-  integrity sha512-9F9+MHmqpTF2CtQtV1Nd1MNgGBbnrNKrMERhalb+dleSP4Frizfb8P9qvCtayHWY+AwxNqrNWsE6BhpjmkFZRw==
+"@terascope/node-rdkafka@~2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@terascope/node-rdkafka/-/node-rdkafka-2.7.4.tgz#9826a509f261714df8206c5f321e5e61273b5f23"
+  integrity sha512-jEYPzt3VjPMXTxi2gZ/Vnog19HLVv3WkNedgZxHe9UhMYiNcZuoxZHjlZg4z/koZ+dh43u1r4XYKm7+4ZSDLdw==
   dependencies:
     bindings "^1.3.1"
     nan "^2.14.0"


### PR DESCRIPTION
Update `node-rdkafka`/`librdafka` has increased the max wait time for the kafka fetcher. [`librdkafka@v1.0.0`](https://github.com/edenhill/librdkafka/releases/tag/v1.0.0) changed the default value for `enable.partition.eof` to `false`, while we ignore that particular error and would like it to be false, `node-rdkfakfa` has [logic](https://github.com/Blizzard/node-rdkafka/blob/d2fde4a3a905976b9333a1f6ce9e2780d78568e6/src/workers.cc#L523-L556) that is dependent on it for "consuming" batches.  I also removed setting the default consumer timeout because the consume timeout doesn't work as I would have that and setting that may extend the wait time as well.

This PR also the `librdkafka` version in `terafoundation_kafka_connector` to [`v1.2.2`](https://github.com/edenhill/librdkafka/releases/tag/v1.2.2) (previously `v1.2.1`) which will fix build errors on macos 10.15.