### PR TITLE
v2.5.0 - set the default request.required.acks on the sender to 1

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "2.4.3"
+    "version": "2.5.0"
 }

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "2.4.2"
+    "version": "2.4.3"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-assets",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-assets",
-    "version": "2.4.3",
+    "version": "2.5.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",

--- a/asset/src/kafka_sender/interfaces.ts
+++ b/asset/src/kafka_sender/interfaces.ts
@@ -43,4 +43,13 @@ export interface KafkaSenderConfig extends OpConfig {
      * group leader assigns partitions to group members.
     */
     partition_assignment_strategy?: 'range'|'roundrobin';
+    /**
+     * This field indicates the number of acknowledgements the leader broker
+     * must receive from ISR brokers before responding to the request:
+     * 0=Broker does not send any response/ack to client,
+     * -1 or all=Broker will block until message is committed by all in sync replicas (ISRs).
+     * If there are less than min.insync.replicas (broker configuration) in the ISR set the
+     * produce request will fail.
+    */
+    required_acks: number;
 }

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -104,6 +104,10 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
                 'batch.num.messages': this.opConfig.size,
                 'topic.metadata.refresh.interval.ms': this.opConfig.metadata_refresh,
                 'log.connection.close': false,
+                // librdkafka >1.0.0 changed the default broker acknowledgement
+                // to all brokers, but this has performance issues
+                // so we should to back to 1
+                'request.required.acks': 1
             },
             autoconnect: false
         };

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -106,8 +106,7 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
                 'log.connection.close': false,
                 // librdkafka >1.0.0 changed the default broker acknowledgement
                 // to all brokers, but this has performance issues
-                // so we should to back to 1
-                'request.required.acks': 1
+                'request.required.acks': this.opConfig.required_acks
             },
             autoconnect: false
         };

--- a/asset/src/kafka_sender/schema.ts
+++ b/asset/src/kafka_sender/schema.ts
@@ -53,6 +53,11 @@ export default class Schema extends ConvictSchema<KafkaSenderConfig> {
                 doc: 'Name of partition assignment strategy to use when elected group leader assigns partitions to group members.',
                 default: '',
                 format: ['range', 'roundrobin', '']
+            },
+            required_acks: {
+                doc: 'The number of required broker acknowledgements for a given request, set to -1 for all.',
+                default: 1,
+                format: 'int'
             }
         };
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-asset-bundle",
-    "version": "2.4.3",
+    "version": "2.5.0",
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "private": true,
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-asset-bundle",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "private": true,
     "scripts": {

--- a/test/kafka-sender-schema-spec.ts
+++ b/test/kafka-sender-schema-spec.ts
@@ -27,5 +27,15 @@ describe('Kafka Sender Schema', () => {
                 });
             }).not.toThrowError();
         });
+
+        it('should set the required_acks default to 1', () => {
+            expect(schema.validate({
+                _op: 'kafka_sender',
+                topic: 'hello',
+                size: 1
+            })).toMatchObject({
+                required_acks: 1
+            });
+        });
     });
 });


### PR DESCRIPTION
The `kafka_sender` times increased when updating [librdkafka](https://github.com/edenhill/librdkafka/releases/tag/v1.0.0), the default value for `request.required.acks` was changed from `1` to `-1` (all) which could potentially be causing the performance issues.

This value is no configurable via `required_acks` on the `kafka_sender` operation config. The value is an integer, see the configuration description from librdkafka below.

```txt
This field indicates the number of acknowledgements the leader broker must receive from ISR brokers before responding to the request: 0=Broker does not send any response/ack to client, -1 or all=Broker will block until message is committed by all in sync replicas (ISRs). If there are less than min.insync.replicas (broker configuration) in the ISR set the produce request will fail.
Type: integer
```