### PR TITLE
v2.5.1 - Fix flush issue and use node-rdkafka official npm package

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "2.5.0"
+    "version": "2.5.1"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-assets",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",

--- a/asset/src/_kafka_clients/base-client.ts
+++ b/asset/src/_kafka_clients/base-client.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import once from 'lodash.once';
 import { Logger, isError, pDelay } from '@terascope/job-components';
-import * as kafka from '@terascope/node-rdkafka';
+import * as kafka from 'node-rdkafka';
 import {
     isOkayError,
     wrapError,

--- a/asset/src/_kafka_clients/consumer-client.ts
+++ b/asset/src/_kafka_clients/consumer-client.ts
@@ -1,5 +1,5 @@
 
-import * as kafka from '@terascope/node-rdkafka';
+import * as kafka from 'node-rdkafka';
 import { pDelay, toHumanTime } from '@terascope/job-components';
 import {
     wrapError,

--- a/asset/src/_kafka_clients/producer-client.ts
+++ b/asset/src/_kafka_clients/producer-client.ts
@@ -1,4 +1,4 @@
-import * as kafka from '@terascope/node-rdkafka';
+import * as kafka from 'node-rdkafka';
 import { ProduceMessage, ProducerClientConfig } from './interfaces';
 import { wrapError, AnyKafkaError } from '../_kafka_helpers';
 import BaseClient from './base-client';

--- a/asset/src/kafka_dead_letter/api.ts
+++ b/asset/src/kafka_dead_letter/api.ts
@@ -7,7 +7,7 @@ import {
     parseError,
     Collector,
 } from '@terascope/job-components';
-import * as kafka from '@terascope/node-rdkafka';
+import * as kafka from 'node-rdkafka';
 import { KafkaDeadLetterConfig } from './interfaces';
 import { ProducerClient, ProduceMessage } from '../_kafka_clients';
 

--- a/asset/src/kafka_reader/fetcher.ts
+++ b/asset/src/kafka_reader/fetcher.ts
@@ -5,7 +5,7 @@ import {
     ConnectionConfig,
     DataEntity
 } from '@terascope/job-components';
-import * as kafka from '@terascope/node-rdkafka';
+import * as kafka from 'node-rdkafka';
 import { KafkaReaderConfig } from './interfaces';
 import { ConsumerClient } from '../_kafka_clients';
 import {

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -7,7 +7,7 @@ import {
     getValidDate,
     isString,
 } from '@terascope/job-components';
-import * as kafka from '@terascope/node-rdkafka';
+import * as kafka from 'node-rdkafka';
 import { KafkaSenderConfig } from './interfaces';
 import { ProducerClient, ProduceMessage } from '../_kafka_clients';
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "license": "MIT",
     "devDependencies": {
         "@terascope/eslint-config": "^0.1.7",
-        "@types/jest": "^24.0.22",
+        "@types/jest": "^24.0.23",
         "@types/lodash.once": "^4.1.6",
-        "@types/node": "^12.12.7",
+        "@types/node": "^12.12.8",
         "@types/uuid": "^3.4.6",
         "bunyan": "^1.8.12",
         "eslint": "^6.6.0",
@@ -34,7 +34,7 @@
         "markdown-toc": "^1.2.0",
         "teraslice-test-harness": "^0.8.13",
         "ts-jest": "^24.1.0",
-        "ts-node": "^8.5.0",
+        "ts-node": "^8.5.2",
         "typescript": "^3.7.2",
         "uuid": "^3.3.3"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-asset-bundle",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "private": true,
     "scripts": {

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -21,7 +21,7 @@
     "author": "Terascope, LLC <info@terascope.io>",
     "license": "MIT",
     "dependencies": {
-        "@terascope/node-rdkafka": "~2.7.4"
+        "node-rdkafka": "~2.7.4"
     },
     "devDependencies": {
         "@terascope/job-components": "^0.23.9",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation_kafka_connector",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "publishConfig": {
         "access": "public"

--- a/packages/terafoundation_kafka_connector/src/index.ts
+++ b/packages/terafoundation_kafka_connector/src/index.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@terascope/job-components';
-import { KafkaConsumer, Producer } from '@terascope/node-rdkafka';
+import { KafkaConsumer, Producer } from 'node-rdkafka';
 import schema from './schema';
 import {
     KafkaConnectorConfig,

--- a/packages/terafoundation_kafka_connector/src/interfaces.ts
+++ b/packages/terafoundation_kafka_connector/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { KafkaConsumer, Producer } from '@terascope/node-rdkafka';
+import { KafkaConsumer, Producer } from 'node-rdkafka';
 
 export interface KafkaConnectorConfig {
     /** A list of brokers */

--- a/test/helpers/kafka-admin.ts
+++ b/test/helpers/kafka-admin.ts
@@ -1,5 +1,5 @@
 import { debugLogger, pDelay } from '@terascope/job-components';
-import { AdminClient, InternalAdminClient } from '@terascope/node-rdkafka';
+import { AdminClient, InternalAdminClient } from 'node-rdkafka';
 import { ERR_UNKNOWN_TOPIC_OR_PART } from '../../asset/src/_kafka_helpers/error-codes';
 import { kafkaBrokers } from './config';
 

--- a/test/helpers/kafka-data.ts
+++ b/test/helpers/kafka-data.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import uuidv4 from 'uuid/v4';
 import { debugLogger } from '@terascope/job-components';
-import * as kafka from '@terascope/node-rdkafka';
+import * as kafka from 'node-rdkafka';
 import { kafkaBrokers } from './config';
 import { ProducerClient, ConsumerClient } from '../../asset/src/_kafka_clients';
 

--- a/test/kafka-slicer-spec.ts
+++ b/test/kafka-slicer-spec.ts
@@ -1,7 +1,7 @@
 import 'jest-extended';
 import { TestClientConfig, Logger } from '@terascope/job-components';
 import { SlicerTestHarness, newTestJobConfig } from 'teraslice-test-harness';
-import Connector from '../packages/terafoundation_kafka_connector';
+import Connector from '../packages/terafoundation_kafka_connector/dist';
 
 describe('Kafka Slicer', () => {
     const clientConfig: TestClientConfig = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,14 +355,6 @@
     datemath-parser "^1.0.6"
     uuid "^3.3.3"
 
-"@terascope/node-rdkafka@~2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@terascope/node-rdkafka/-/node-rdkafka-2.7.4.tgz#9826a509f261714df8206c5f321e5e61273b5f23"
-  integrity sha512-jEYPzt3VjPMXTxi2gZ/Vnog19HLVv3WkNedgZxHe9UhMYiNcZuoxZHjlZg4z/koZ+dh43u1r4XYKm7+4ZSDLdw==
-  dependencies:
-    bindings "^1.3.1"
-    nan "^2.14.0"
-
 "@terascope/queue@^1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@terascope/queue/-/queue-1.1.7.tgz#26cd3a42747ec802744f9b86c08034b0bbe07091"
@@ -3447,6 +3439,14 @@ node-pre-gyp@^0.12.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-rdkafka@~2.7.4:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.7.4.tgz#b777f5ba9dd08578c6f1d4fe58d51f3c13372413"
+  integrity sha512-415Hfu2SkAo9+mSj3xxw+dHwJqC0jRY0D/OKqUdPfvEE1r4p+N0OfbsAmmSR5FSxZFRFTY3j+/tGntp6ssqHWw==
+  dependencies:
+    bindings "^1.3.1"
+    nan "^2.14.0"
 
 nopt@^4.0.1:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,17 +446,12 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest-diff@*":
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
-  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
-
-"@types/jest@^24.0.22":
-  version "24.0.22"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.22.tgz#08a50be08e78aba850a1185626e71d31e2336145"
-  integrity sha512-t2OvhNZnrNjlzi2i0/cxbLVM59WN15I2r1Qtb7wDv28PnV9IzrPtagFRey/S9ezdLD0zyh1XGMQIEQND2YEfrw==
+"@types/jest@^24.0.23":
+  version "24.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.23.tgz#046f8e2ade026fe831623e361a36b6fb9a4463e4"
+  integrity sha512-L7MBvwfNpe7yVPTXLn32df/EK+AMBFAFvZrRuArGs7npEWnlziUXK+5GMIUTI4NIuwok3XibsjXCs5HxviYXjg==
   dependencies:
-    "@types/jest-diff" "*"
+    jest-diff "^24.3.0"
 
 "@types/json-schema@^7.0.3":
   version "7.0.3"
@@ -475,10 +470,15 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.135.tgz#d2607c35dd68f70c2b35ba020c667493dedd8447"
   integrity sha512-Ed+tSZ9qM1oYpi5kzdsBuOzcAIn1wDW+e8TFJ50IMJMlSopGdJgKAbhHzN6h1E1OfjlGOr2JepzEWtg9NIfoNg==
 
-"@types/node@*", "@types/node@^12.12.7":
+"@types/node@*":
   version "12.12.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.7.tgz#01e4ea724d9e3bd50d90c11fd5980ba317d8fa11"
   integrity sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==
+
+"@types/node@^12.12.8":
+  version "12.12.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.8.tgz#dab418655af39ce2fa99286a0bed21ef8072ac9d"
+  integrity sha512-XLla8N+iyfjvsa0KKV+BP/iGSoTmwxsu5Ci5sM33z9TjohF72DEz95iNvD6pPmemvbQgxAv/909G73gUn8QR7w==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2491,6 +2491,16 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
+jest-diff@^24.3.0, jest-diff@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
+
 jest-diff@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.8.0.tgz#146435e7d1e3ffdf293d53ff97e193f1d1546172"
@@ -2500,16 +2510,6 @@ jest-diff@^24.8.0:
     diff-sequences "^24.3.0"
     jest-get-type "^24.8.0"
     pretty-format "^24.8.0"
-
-jest-diff@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
-  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
-  dependencies:
-    chalk "^2.0.1"
-    diff-sequences "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
 
 jest-docblock@^24.3.0:
   version "24.3.0"
@@ -4695,10 +4695,10 @@ ts-jest@^24.1.0:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-node@^8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.0.tgz#bc7d5a39133d222bf25b1693651e4d893785f884"
-  integrity sha512-fbG32iZEupNV2E2Fd2m2yt1TdAwR3GTCrJQBHDevIiEBNy1A8kqnyl1fv7jmRmmbtcapFab2glZXHJvfD1ed0Q==
+ts-node@^8.5.2:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.2.tgz#434f6c893bafe501a30b32ac94ee36809ba2adce"
+  integrity sha512-W1DK/a6BGoV/D4x/SXXm6TSQx6q3blECUzd5TN+j56YEMX3yPVMpHsICLedUw3DvGF3aTQ8hfdR9AKMaHjIi+A==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"


### PR DESCRIPTION
- Updates `terafoundation_kafka_connector` (0.5.3) to use official `node-rdkafka` npm package instead of our forked one.
- Fixes a `kafka_sender` issue that will  cause unnecessary flushing
- Updates a couple dev dependencies