### PR TITLE
routing support in conjuction with routers from standard-assets

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "2.6.0"
+    "version": "2.7.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-assets",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",

--- a/asset/package.json
+++ b/asset/package.json
@@ -5,7 +5,7 @@
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",
     "dependencies": {
-        "@terascope/job-components": "^0.28.2",
+        "@terascope/job-components": "^0.30.0",
         "lodash.once": "^4.1.1"
     },
     "devDependencies": {},

--- a/asset/src/kafka_reader/index.ts
+++ b/asset/src/kafka_reader/index.ts
@@ -1,8 +1,0 @@
-import { legacyReaderShim } from '@terascope/job-components';
-import Fetcher from './fetcher';
-import Slicer from './slicer';
-import Schema from './schema';
-
-// This file for backwards compatibility and functionality will be limited
-// but it should allow you to write processors using the new way today
-export default legacyReaderShim(Slicer, Fetcher, Schema);

--- a/asset/src/kafka_sender/index.ts
+++ b/asset/src/kafka_sender/index.ts
@@ -1,7 +1,0 @@
-import { legacyProcessorShim } from '@terascope/job-components';
-import Processor from './processor';
-import Schema from './schema';
-
-// This file for backwards compatibility and functionality will be limited
-// but it should allow you to write processors using the new way today
-export default legacyProcessorShim(Processor, Schema);

--- a/asset/src/kafka_sender/interfaces.ts
+++ b/asset/src/kafka_sender/interfaces.ts
@@ -52,4 +52,8 @@ export interface KafkaSenderConfig extends OpConfig {
      * produce request will fail.
     */
     required_acks: number;
+    /**
+     * partition keys to terafoundation kafka connector names
+    */
+    connection_map: Record<string, string>;
 }

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -132,7 +132,14 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
                 const routeConfig = this.topicMap.get('*') as Endpoint;
                 routeConfig.data.push(record);
             } else {
-                const error = new TSError(`Invalid connection route: ${route}`);
+                let error: TSError;
+
+                if (route == null) {
+                    error = new TSError('No route was specified in record metadata');
+                } else {
+                    error = new TSError(`Invalid connection route: ${route} was not found on connector_map`);
+                }
+
                 this.rejectRecord(record, error);
             }
         }

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -40,14 +40,16 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
         for (const keyset of Object.keys(connectionMap)) {
             const client = this.createClient(connectionMap[keyset]);
             const keys = keyset.split(',');
-            const producer = new ProducerClient(client, {
-                logger,
-                topic,
-                bufferSize: this._bufferSize,
-            });
 
             for (const key of keys) {
-                this.topicMap[key.toLowerCase()] = {
+                const newTopic = key === '*' ? topic : `${topic}-${key}`;
+                const producer = new ProducerClient(client, {
+                    logger,
+                    topic: newTopic,
+                    bufferSize: this._bufferSize,
+                });
+
+                this.topicMap[key] = {
                     producer,
                     data: []
                 };

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -6,14 +6,24 @@ import {
     ConnectionConfig,
     getValidDate,
     isString,
+    has,
 } from '@terascope/job-components';
 import * as kafka from 'node-rdkafka';
 import { KafkaSenderConfig } from './interfaces';
 import { ProducerClient, ProduceMessage } from '../_kafka_clients';
 
-export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
+interface Endpoint {
     producer: ProducerClient;
+    data: any[];
+}
+
+interface TopicMap {
+    [key: string]: Endpoint;
+}
+
+export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
     private _bufferSize: number;
+    topicMap: TopicMap = {};
 
     constructor(
         context: WorkerContext,
@@ -21,30 +31,83 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
         executionConfig: ExecutionConfig
     ) {
         super(context, opConfig, executionConfig);
+        const { topic, size, connection_map: connectionMap } = opConfig;
 
         const logger = this.logger.child({ module: 'kafka-producer' });
 
-        this._bufferSize = this.opConfig.size * 5;
+        this._bufferSize = size * 5;
 
-        this.producer = new ProducerClient(this.createClient(), {
-            logger,
-            topic: this.opConfig.topic,
-            bufferSize: this._bufferSize,
-        });
+        for (const keyset of Object.keys(connectionMap)) {
+            const client = this.createClient(connectionMap[keyset]);
+            const keys = keyset.split(',');
+            const producer = new ProducerClient(client, {
+                logger,
+                topic,
+                bufferSize: this._bufferSize,
+            });
+
+            for (const key of keys) {
+                this.topicMap[key.toLowerCase()] = {
+                    producer,
+                    data: []
+                };
+            }
+        }
     }
 
     async initialize() {
         await super.initialize();
-        await this.producer.connect();
+        const initList = [];
+
+        for (const [, { producer }] of Object.entries(this.topicMap)) {
+            initList.push(producer.connect());
+        }
+
+        await Promise.all(initList);
+    }
+
+    private _cleanupTopicMap() {
+        for (const [, config] of Object.entries(this.topicMap)) {
+            config.data = [];
+        }
     }
 
     async shutdown() {
-        await this.producer.disconnect();
+        const shutdownList = [];
+
+        for (const [, { producer }] of Object.entries(this.topicMap)) {
+            shutdownList.push(producer.disconnect());
+        }
+
+        await Promise.all(shutdownList);
         await super.shutdown();
     }
 
     async onBatch(batch: DataEntity[]) {
-        await this.producer.produce(batch, this.mapFn());
+        const senders = [];
+
+        for (const record of batch) {
+            const partition = record.getMetadata('_partition');
+
+            if (has(this.topicMap, partition)) {
+                this.topicMap[partition].data.push(record);
+            } else if (has(this.topicMap, '*')) {
+                this.topicMap['*'].data.push(record);
+            } else {
+                // TODO: should we just drop it?
+                this.logger.error(`Invalid connection partition: ${partition}`);
+            }
+        }
+
+        for (const [, { data, producer }] of Object.entries(this.topicMap)) {
+            if (data.length > 0) {
+                senders.push(producer.produce(data, this.mapFn()));
+            }
+        }
+
+        await Promise.all(senders);
+
+        this._cleanupTopicMap();
         return batch;
     }
 
@@ -90,10 +153,10 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
         };
     }
 
-    private clientConfig() {
+    private clientConfig(connection?: string) {
         const config = {
             type: 'kafka',
-            endpoint: this.opConfig.connection,
+            endpoint: connection || this.opConfig.connection,
             options: {
                 type: 'producer'
             },
@@ -119,9 +182,9 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
         return config as ConnectionConfig;
     }
 
-    private createClient(): kafka.Producer {
-        const config = this.clientConfig();
-        const connection = this.context.foundation.getConnection(config);
-        return connection.client;
+    private createClient(connection?: string): kafka.Producer {
+        const config = this.clientConfig(connection);
+        const { client } = this.context.foundation.getConnection(config);
+        return client;
     }
 }

--- a/asset/src/kafka_sender/schema.ts
+++ b/asset/src/kafka_sender/schema.ts
@@ -14,13 +14,12 @@ export default class Schema extends ConvictSchema<KafkaSenderConfig> {
         const opConfig = fetchConfig(job);
         const kafkaConnectors = get(this.context, 'sysconfig.terafoundation.connectors.kafka');
         if (kafkaConnectors == null) throw new Error('Could not find kafka connector in terafoundation config');
-
         // check to verify if connection map provided is
         // consistent with sysconfig.terafoundation.connectors
         if (opConfig.connection_map) {
             for (const value of Object.values(opConfig.connection_map)) {
                 if (!kafkaConnectors[value]) {
-                    throw new Error(`A connection for [${value}] was set on the kafka_sender connection_map but is not found in the system configuration [terafoundation.connectors.elasticsearch]`);
+                    throw new Error(`A connection for [${value}] was set on the kafka_sender connection_map but is not found in the system configuration [terafoundation.connectors.kafka]`);
                 }
             }
         }

--- a/asset/yarn.lock
+++ b/asset/yarn.lock
@@ -2,36 +2,37 @@
 # yarn lockfile v1
 
 
-"@terascope/job-components@^0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.28.2.tgz#99d6d0faa61ef732399942bf28afd4b54ade077f"
-  integrity sha512-+CAGi1mM9vnaAWIMRK1fgQhboQC0vURdgzW8lzQRq3jUrnj6M1vlqgIbPDLYbO0k8EgeUGjpIj08G87j1hIHMA==
+"@terascope/job-components@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.30.0.tgz#b3239ed73afe9dc6b1228b1f3c8a030d681c3b07"
+  integrity sha512-XbXblMbEsEwzv4ZucZID6K8uJQLRYknl+GG5Ww3rMZALVAR60PUuYwv1UXfLGFjRNfaOHJ4w6YlWaEw51vAWgw==
   dependencies:
-    "@terascope/utils" "^0.23.2"
+    "@terascope/utils" "^0.24.2"
     convict "^4.4.1"
     datemath-parser "^1.0.6"
-    uuid "^3.4.0"
+    uuid "^7.0.1"
 
-"@terascope/types@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.1.2.tgz#ff95bf7ff48eb96ae0bff7dece0f85abf217558d"
-  integrity sha512-lYd3t6B8FTmvfZ2pXnQEfgAYNVro4FEw2VgRAB8CBmactCOA12xiStrP7Vqehva5ELgvnovFFqK5my10Ms8hwA==
+"@terascope/types@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.1.3.tgz#9be5f483d2e87004f00896069d5112618ae4a3cb"
+  integrity sha512-GzCeaZpLWnZXxpTxnR/dwIbXDO3pVAUOKZbpILPKpvldHdO5gectWke6ysGPFwcWK/e/6c0i+VBzFL57DquYJw==
 
-"@terascope/utils@^0.23.2":
-  version "0.23.2"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.23.2.tgz#faea098877d31f78b818a30e1b074bb8453e97f4"
-  integrity sha512-4/lAnLXttuUE2wX03kyAY3j9bXT3cQffe7YOCaYLfQdG+Jjh1sGmq4YRmYMbgUbiTCb2h+y5ZpdWe2cK0Cwapg==
+"@terascope/utils@^0.24.2":
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.24.2.tgz#f2a6b9552b84a8f41cc238117b1ae2432ee94cf7"
+  integrity sha512-QLhHnjWq+It5Bb9HVILstDoEREslJWhRfaLAjCbbqqD0x92lGUl7D1tmLtDFoyFa4sfZaYOggZyFuHxrr0lFnw==
   dependencies:
-    "@terascope/types" "^0.1.2"
+    "@terascope/types" "^0.1.3"
     debug "^4.1.1"
     is-plain-object "^3.0.0"
     js-string-escape "^1.0.1"
     kind-of "^6.0.3"
     latlon-geohash "^1.1.0"
-    lodash.clonedeep "^4.5.0"
     lodash.get "^4.4.2"
+    lodash.has "^4.5.2"
     lodash.set "^4.3.2"
     lodash.unset "^4.5.2"
+    shallow-clone "^3.0.1"
 
 camelcase@^5.0.0:
   version "5.3.1"
@@ -98,7 +99,7 @@ json5@1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-kind-of@^6.0.3:
+kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -108,7 +109,7 @@ latlon-geohash@^1.1.0:
   resolved "https://registry.yarnpkg.com/latlon-geohash/-/latlon-geohash-1.1.0.tgz#7abe15224c4800e3eaecac71c753a20bfb6cbf65"
   integrity sha1-er4VIkxIAOPq7Kxxx1OiC/tsv2U=
 
-lodash.clonedeep@4.5.0, lodash.clonedeep@^4.5.0:
+lodash.clonedeep@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
@@ -117,6 +118,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.has@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
 
 lodash.once@^4.1.1:
   version "4.1.1"
@@ -153,10 +159,17 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-uuid@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+shallow-clone@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
+
+uuid@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
+  integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
 
 validator@10.8.0:
   version "10.8.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "@terascope/eslint-config": "^0.2.4",
         "@types/jest": "^25.1.3",
         "@types/lodash.once": "^4.1.6",
-        "@types/node": "^13.7.4",
+        "@types/node": "^13.7.7",
         "@types/uuid": "^3.4.7",
         "bunyan": "^1.8.12",
         "eslint": "^6.7.2",
@@ -32,10 +32,10 @@
         "jest-extended": "^0.11.5",
         "markdown-table": "^2.0.0",
         "markdown-toc": "^1.2.0",
-        "teraslice-test-harness": "^0.13.1",
+        "teraslice-test-harness": "^0.13.2",
         "ts-jest": "^25.2.1",
         "ts-node": "^8.6.2",
-        "typescript": "^3.8.2",
+        "typescript": "^3.8.3",
         "uuid": "^3.4.0"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "jest-extended": "^0.11.5",
         "markdown-table": "^2.0.0",
         "markdown-toc": "^1.2.0",
-        "teraslice-test-harness": "^0.13.2",
+        "teraslice-test-harness": "^0.15.0",
         "ts-jest": "^25.2.1",
         "ts-node": "^8.6.2",
         "typescript": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-asset-bundle",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "private": true,
     "scripts": {

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -24,7 +24,7 @@
         "node-rdkafka": "~2.7.4"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.28.2",
+        "@terascope/job-components": "^0.30.0",
         "@types/convict": "^4.2.1",
         "convict": "^4.4.1"
     },

--- a/test/kafka-fetcher-spec.ts
+++ b/test/kafka-fetcher-spec.ts
@@ -39,7 +39,8 @@ describe('Kafka Fetcher', () => {
                 group,
                 size: 100,
                 wait: 8000,
-                rollback_on_failure: true
+                rollback_on_failure: true,
+                _dead_letter_action: 'log'
             },
             {
                 _op: 'noop'

--- a/test/kafka-multisend-spec.ts
+++ b/test/kafka-multisend-spec.ts
@@ -1,0 +1,153 @@
+import 'jest-extended';
+import { TestClientConfig, Logger, DataEntity } from '@terascope/job-components';
+import { WorkerTestHarness, newTestJobConfig } from 'teraslice-test-harness';
+import KafkaSender from '../asset/src/kafka_sender/processor';
+import { readData } from './helpers/kafka-data';
+import Connector from '../packages/terafoundation_kafka_connector/dist';
+import { kafkaBrokers, senderTopic } from './helpers/config';
+import KafkaAdmin from './helpers/kafka-admin';
+
+describe('Kafka Sender', () => {
+    jest.setTimeout(15 * 1000);
+    const mockFlush = jest.fn();
+    const topicMeta1 = 'billy';
+    const topicMeta2 = 'fred';
+    const connectionEndpoint2 = 'kafka-2';
+
+    const firstTopic = `${senderTopic}-${topicMeta1}`;
+    const secondTopic = `${senderTopic}-${topicMeta2}`;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const connectorMap: Record<string, string> = {
+        [topicMeta1]: 'default',
+        [topicMeta2]: connectionEndpoint2
+    };
+
+    const clientConfig: TestClientConfig = {
+        type: 'kafka',
+        config: {
+            brokers: kafkaBrokers,
+        },
+        create(config: any, logger: Logger, settings: any) {
+            const result = Connector.create(config, logger, settings);
+            // @ts-ignore
+            result.client.flush = mockFlush
+                // @ts-ignore
+                .mockImplementation(result.client.flush)
+                .bind(result.client);
+            return result;
+        },
+        endpoint: 'default'
+    };
+
+    const clientConfig2: TestClientConfig = {
+        type: 'kafka',
+        config: {
+            brokers: kafkaBrokers,
+        },
+        create(config: any, logger: Logger, settings: any) {
+            const result = Connector.create(config, logger, settings);
+            // @ts-ignore
+            result.client.flush = mockFlush
+                // @ts-ignore
+                .mockImplementation(result.client.flush)
+                .bind(result.client);
+            return result;
+        },
+        endpoint: connectionEndpoint2
+    };
+
+    const topic = senderTopic;
+
+    const clients = [clientConfig, clientConfig2];
+    const batchSize = 100;
+
+    const job = newTestJobConfig({
+        max_retries: 3,
+        operations: [
+            {
+                _op: 'test-reader',
+            },
+            {
+                _op: 'kafka_sender',
+                topic,
+                size: batchSize,
+                connection_map: connectorMap
+            }
+        ],
+    });
+
+    const admin = new KafkaAdmin();
+
+    let harness: WorkerTestHarness;
+    let sender: KafkaSender;
+    let input: DataEntity[] = [];
+
+    beforeAll(async () => {
+        jest.clearAllMocks();
+
+        await Promise.all([
+            admin.ensureTopic(firstTopic),
+            admin.ensureTopic(secondTopic)
+        ]);
+
+        harness = new WorkerTestHarness(job, {
+            clients,
+        });
+
+        harness.fetcher().handle = async () => input;
+
+        sender = harness.getOperation('kafka_sender') as any;
+
+        await harness.initialize();
+
+        const initList = [];
+
+        for (const [, { producer }] of Object.entries(sender.topicMap)) {
+            initList.push(producer.connect());
+        }
+
+        await Promise.all(initList);
+    });
+
+    afterAll(async () => {
+        jest.clearAllMocks();
+
+        admin.disconnect();
+
+        // it should be able to disconnect twice
+        const shutdownList = [];
+
+        for (const [, { producer }] of Object.entries(sender.topicMap)) {
+            shutdownList.push(producer.disconnect());
+        }
+
+        await Promise.all(shutdownList);
+        await harness.shutdown();
+    });
+
+    it('run', async () => {
+        const obj1 = { hello: 'world' };
+        const obj2 = { foo: 'bar' };
+
+        input = [
+            DataEntity.make(obj1, { _partition: topicMeta1 }),
+            DataEntity.make(obj2, { _partition: topicMeta2 })
+        ];
+
+        const results = await harness.runSlice({});
+
+        expect(results).toBeArrayOfSize(2);
+
+        const [topic1, topic2] = await Promise.all([
+            readData(firstTopic, 100),
+            readData(secondTopic, 100)
+        ]);
+
+        expect(topic1).toBeArrayOfSize(1);
+        expect(topic1[0]).toEqual(obj1);
+
+        expect(topic2).toBeArrayOfSize(1);
+        expect(topic2[0]).toEqual(obj2);
+    });
+});

--- a/test/kafka-multisend-spec.ts
+++ b/test/kafka-multisend-spec.ts
@@ -126,13 +126,13 @@ describe('Kafka Sender', () => {
         await harness.shutdown();
     });
 
-    it('run', async () => {
+    it('can send to two topics', async () => {
         const obj1 = { hello: 'world' };
         const obj2 = { foo: 'bar' };
 
         input = [
-            DataEntity.make(obj1, { _partition: topicMeta1 }),
-            DataEntity.make(obj2, { _partition: topicMeta2 })
+            DataEntity.make(obj1, { 'standard:route': topicMeta1 }),
+            DataEntity.make(obj2, { 'standard:route': topicMeta2 })
         ];
 
         const results = await harness.runSlice({});

--- a/test/kafka-multisend-spec.ts
+++ b/test/kafka-multisend-spec.ts
@@ -10,8 +10,9 @@ import KafkaAdmin from './helpers/kafka-admin';
 describe('Kafka Sender', () => {
     jest.setTimeout(15 * 1000);
     const mockFlush = jest.fn();
-    const topicMeta1 = 'billy';
-    const topicMeta2 = 'fred';
+    const topicMeta1 = 'b';
+    const topicMeta2 = 'F';
+    const connectionEndpoint1 = 'kafka-1';
     const connectionEndpoint2 = 'kafka-2';
 
     const firstTopic = `${senderTopic}-${topicMeta1}`;
@@ -19,11 +20,12 @@ describe('Kafka Sender', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const connectorMap: Record<string, string> = {
-        [topicMeta1]: 'default',
-        [topicMeta2]: connectionEndpoint2
+        'a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p': connectionEndpoint1,
+        'q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,I': connectionEndpoint2,
+        'J,K,L,M,O,P,Q,R,S,T,U,V,W,X,Y,Z,1,2,3,4,5,6,7,8,9,0,+,=': connectionEndpoint2
     };
 
-    const clientConfig: TestClientConfig = {
+    const kafkaConfig1: TestClientConfig = {
         type: 'kafka',
         config: {
             brokers: kafkaBrokers,
@@ -37,10 +39,10 @@ describe('Kafka Sender', () => {
                 .bind(result.client);
             return result;
         },
-        endpoint: 'default'
+        endpoint: connectionEndpoint1
     };
 
-    const clientConfig2: TestClientConfig = {
+    const kafkaConfig2: TestClientConfig = {
         type: 'kafka',
         config: {
             brokers: kafkaBrokers,
@@ -59,7 +61,7 @@ describe('Kafka Sender', () => {
 
     const topic = senderTopic;
 
-    const clients = [clientConfig, clientConfig2];
+    const clients = [kafkaConfig1, kafkaConfig2];
     const batchSize = 100;
 
     const job = newTestJobConfig({

--- a/test/kafka-sender-spec.ts
+++ b/test/kafka-sender-spec.ts
@@ -51,7 +51,8 @@ describe('Kafka Sender', () => {
             {
                 _op: 'kafka_sender',
                 topic,
-                size: batchSize
+                size: batchSize,
+                _dead_letter_action: 'log'
             }
         ],
     });

--- a/test/kafka-sender-spec.ts
+++ b/test/kafka-sender-spec.ts
@@ -80,7 +80,7 @@ describe('Kafka Sender', () => {
 
         const initList = [];
 
-        for (const [, { producer }] of Object.entries(sender.topicMap)) {
+        for (const { producer } of sender.topicMap.values()) {
             initList.push(producer.connect());
         }
 
@@ -106,7 +106,7 @@ describe('Kafka Sender', () => {
         // it should be able to disconnect twice
         const shutdownList = [];
 
-        for (const [, { producer }] of Object.entries(sender.topicMap)) {
+        for (const { producer } of sender.topicMap.values()) {
             shutdownList.push(producer.disconnect());
         }
 
@@ -116,15 +116,22 @@ describe('Kafka Sender', () => {
 
     it('should able to call _clientEvents without double listening', () => {
         // @ts-ignore
-        const expected = sender.topicMap['*'].producer._client.listenerCount('error');
+        const expectedTopic = sender.topicMap.get('default');
+        // @ts-ignore
+        const expected = expectedTopic.producer._client.listenerCount('error');
 
         expect(() => {
             // @ts-ignore
-            sender.topicMap['*'].producer._clientEvents();
+            const testTopic = sender.topicMap.get('default');
+            // @ts-ignore
+            testTopic.producer._clientEvents();
         }).not.toThrowError();
 
         // @ts-ignore
-        const actual = sender.topicMap['*'].producer._client.listenerCount('error');
+        const actualTopic = sender.topicMap.get('default');
+        // @ts-ignore
+        const actual = actualTopic.producer._client.listenerCount('error');
+
         expect(actual).toEqual(expected);
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,44 +519,45 @@
     eslint-plugin-react "^7.18.0"
     eslint-plugin-react-hooks "^2.3.0"
 
-"@terascope/job-components@^0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.28.2.tgz#99d6d0faa61ef732399942bf28afd4b54ade077f"
-  integrity sha512-+CAGi1mM9vnaAWIMRK1fgQhboQC0vURdgzW8lzQRq3jUrnj6M1vlqgIbPDLYbO0k8EgeUGjpIj08G87j1hIHMA==
+"@terascope/job-components@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.30.0.tgz#b3239ed73afe9dc6b1228b1f3c8a030d681c3b07"
+  integrity sha512-XbXblMbEsEwzv4ZucZID6K8uJQLRYknl+GG5Ww3rMZALVAR60PUuYwv1UXfLGFjRNfaOHJ4w6YlWaEw51vAWgw==
   dependencies:
-    "@terascope/utils" "^0.23.2"
+    "@terascope/utils" "^0.24.2"
     convict "^4.4.1"
     datemath-parser "^1.0.6"
-    uuid "^3.4.0"
+    uuid "^7.0.1"
 
-"@terascope/teraslice-op-test-harness@^1.12.2":
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/@terascope/teraslice-op-test-harness/-/teraslice-op-test-harness-1.12.2.tgz#17c5a760fd68a7d52ce60b4074459213129ee95b"
-  integrity sha512-RHpPBNKKnSk4PB0xZSNB/fks/iP5OE80OfY4H5Ld2qTHcLqr2Qg7NwDzuhk6Oc/ulEPKu3iwdsO/RHQEbtd2yw==
+"@terascope/teraslice-op-test-harness@^1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@terascope/teraslice-op-test-harness/-/teraslice-op-test-harness-1.14.0.tgz#874ef776eab691b7ad60e92bb4117544e1744940"
+  integrity sha512-qAGwiBAl2VoTFQWendSICLbqFBc8cPJS2vsSpu+5IjDP6xm/cYFekh6ebkknNxKQvbkMncjxyc77nI2GUaYQfQ==
   dependencies:
-    "@terascope/job-components" "^0.28.2"
+    "@terascope/job-components" "^0.30.0"
     bluebird "^3.7.2"
 
-"@terascope/types@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.1.2.tgz#ff95bf7ff48eb96ae0bff7dece0f85abf217558d"
-  integrity sha512-lYd3t6B8FTmvfZ2pXnQEfgAYNVro4FEw2VgRAB8CBmactCOA12xiStrP7Vqehva5ELgvnovFFqK5my10Ms8hwA==
+"@terascope/types@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.1.3.tgz#9be5f483d2e87004f00896069d5112618ae4a3cb"
+  integrity sha512-GzCeaZpLWnZXxpTxnR/dwIbXDO3pVAUOKZbpILPKpvldHdO5gectWke6ysGPFwcWK/e/6c0i+VBzFL57DquYJw==
 
-"@terascope/utils@^0.23.2":
-  version "0.23.2"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.23.2.tgz#faea098877d31f78b818a30e1b074bb8453e97f4"
-  integrity sha512-4/lAnLXttuUE2wX03kyAY3j9bXT3cQffe7YOCaYLfQdG+Jjh1sGmq4YRmYMbgUbiTCb2h+y5ZpdWe2cK0Cwapg==
+"@terascope/utils@^0.24.2":
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.24.2.tgz#f2a6b9552b84a8f41cc238117b1ae2432ee94cf7"
+  integrity sha512-QLhHnjWq+It5Bb9HVILstDoEREslJWhRfaLAjCbbqqD0x92lGUl7D1tmLtDFoyFa4sfZaYOggZyFuHxrr0lFnw==
   dependencies:
-    "@terascope/types" "^0.1.2"
+    "@terascope/types" "^0.1.3"
     debug "^4.1.1"
     is-plain-object "^3.0.0"
     js-string-escape "^1.0.1"
     kind-of "^6.0.3"
     latlon-geohash "^1.1.0"
-    lodash.clonedeep "^4.5.0"
     lodash.get "^4.4.2"
+    lodash.has "^4.5.2"
     lodash.set "^4.3.2"
     lodash.unset "^4.5.2"
+    shallow-clone "^3.0.1"
 
 "@types/babel__core@^7.1.0":
   version "7.1.3"
@@ -3286,7 +3287,7 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.clonedeep@4.5.0, lodash.clonedeep@^4.5.0:
+lodash.clonedeep@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
@@ -3295,6 +3296,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.has@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -4350,6 +4356,13 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+shallow-clone@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -4698,13 +4711,13 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-teraslice-test-harness@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/teraslice-test-harness/-/teraslice-test-harness-0.13.2.tgz#94ce21e89d07f0f10882078406de5dffe542ce79"
-  integrity sha512-TBc4YPN6tp0Jf9YFB4KwKKrxvZdDMthT26Cdskmvyx0tKXeaOP3YOQNsM8N0c7W+qLGk4rUpOA9TvsV/+fVn/g==
+teraslice-test-harness@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/teraslice-test-harness/-/teraslice-test-harness-0.15.0.tgz#be51e3809e9697a059a990afa4f20c293404533d"
+  integrity sha512-7FMs+o4itsw2qTnjn3yFS4C45VLWaeAxzSJdMTqAp8Ga1R+y4aMffVR+FP4q7S22WuE2eb2vtHPS9mNGuIn4vQ==
   dependencies:
-    "@terascope/job-components" "^0.28.2"
-    "@terascope/teraslice-op-test-harness" "^1.12.2"
+    "@terascope/job-components" "^0.30.0"
+    "@terascope/teraslice-op-test-harness" "^1.14.0"
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -4969,6 +4982,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
+  integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,7 +519,7 @@
     eslint-plugin-react "^7.18.0"
     eslint-plugin-react-hooks "^2.3.0"
 
-"@terascope/job-components@^0.28.1", "@terascope/job-components@^0.28.2":
+"@terascope/job-components@^0.28.2":
   version "0.28.2"
   resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.28.2.tgz#99d6d0faa61ef732399942bf28afd4b54ade077f"
   integrity sha512-+CAGi1mM9vnaAWIMRK1fgQhboQC0vURdgzW8lzQRq3jUrnj6M1vlqgIbPDLYbO0k8EgeUGjpIj08G87j1hIHMA==
@@ -529,12 +529,12 @@
     datemath-parser "^1.0.6"
     uuid "^3.4.0"
 
-"@terascope/teraslice-op-test-harness@^1.12.1":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@terascope/teraslice-op-test-harness/-/teraslice-op-test-harness-1.12.1.tgz#13ae791e541d41407510e0d9fb6b63ac1ca438fb"
-  integrity sha512-KdkfidGHdKJc5Ydvx73aHP0LMOn38ri4INmbVudg5ukzG9solm542yYsLLoVzbq2oovjBkXFJFZEFSYW/sc3iw==
+"@terascope/teraslice-op-test-harness@^1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@terascope/teraslice-op-test-harness/-/teraslice-op-test-harness-1.12.2.tgz#17c5a760fd68a7d52ce60b4074459213129ee95b"
+  integrity sha512-RHpPBNKKnSk4PB0xZSNB/fks/iP5OE80OfY4H5Ld2qTHcLqr2Qg7NwDzuhk6Oc/ulEPKu3iwdsO/RHQEbtd2yw==
   dependencies:
-    "@terascope/job-components" "^0.28.1"
+    "@terascope/job-components" "^0.28.2"
     bluebird "^3.7.2"
 
 "@terascope/types@^0.1.2":
@@ -651,10 +651,10 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
-"@types/node@^13.7.4":
-  version "13.7.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.4.tgz#76c3cb3a12909510f52e5dc04a6298cdf9504ffd"
-  integrity sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==
+"@types/node@^13.7.7":
+  version "13.7.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.7.tgz#1628e6461ba8cc9b53196dfeaeec7b07fa6eea99"
+  integrity sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -4698,13 +4698,13 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-teraslice-test-harness@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/teraslice-test-harness/-/teraslice-test-harness-0.13.1.tgz#7806f55064273cbd4f17e83b1b544efd4388ebae"
-  integrity sha512-CX1+Xpj7BtuQS7283ihYaUue8CMyyjTvijqpa6EvJvBAz3eeLGMBlOGeVi+3ooyrjmqq+84E8ny9kHUFTney2A==
+teraslice-test-harness@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/teraslice-test-harness/-/teraslice-test-harness-0.13.2.tgz#94ce21e89d07f0f10882078406de5dffe542ce79"
+  integrity sha512-TBc4YPN6tp0Jf9YFB4KwKKrxvZdDMthT26Cdskmvyx0tKXeaOP3YOQNsM8N0c7W+qLGk4rUpOA9TvsV/+fVn/g==
   dependencies:
-    "@terascope/job-components" "^0.28.1"
-    "@terascope/teraslice-op-test-harness" "^1.12.1"
+    "@terascope/job-components" "^0.28.2"
+    "@terascope/teraslice-op-test-harness" "^1.12.2"
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -4912,10 +4912,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
-  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
- adds support for a `connection_map` similar to how elasticsearch-assets bulk-sender works
- keys must be exact match to partition, this is to be used in combination with the new partition operations in standard assets