### PR TITLE
added ** routing for dynamic record topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,48 @@ terafoundation:
 |         **timestamp_now**         |                      `Boolean`                       |    `false`    |                                                                                                                                                                                           Set to true to have a timestamp generated as records are added to the topic                                                                                                                                                                                            |
 |             **topic**             |                       `String`                       |       -       |                                                                                                                                                                                                             Name of the Kafka topic to send data to                                                                                                                                                                                                              |
 |             **wait**              |                      `duration`                      |     `500`     |                                                                                                                                                                                            How long to wait for `size` messages to become available on the producer.                                                                                                                                                                                             |
+| **connection_map** | `Object` | `null` | This field determines optional custom routing specifications |
+
+**Custom Routing**
+
+The `connection_map` can be used to route records to specific topics in specific connections based on the `standard:route` set on each record. The keys should be a comma-separated list of values to match, and the value should be the target Kafka connector. Additionally, either `*` or `**` can be specified as a key to function as a catch-all for records with a `standard:route` that doesn't match any of the other keys. `*` will set the destination topic to the default specified in the opConfig, and `**` will append the record's `standard:route` to that default. Both **CANNOT** be specified in the same `connection_map`.
+
+**Example `connection_map`s:**
+
+```js
+"topic": "my-data",
+"connection_map": {
+    "1,2": "kafka1",
+    "3,4": "kafka1"
+}
+```
+
+- Records with a `standard:route` of `1` or `2` will go to topic `my-data-1` or `my-data-2` respectively
+- Records with a `standard:route` of `3` or `4` will go to topic `my-data-3` or `my-data-4` respectively
+- All other records will be rejected
+
+```js
+"topic": "my-data",
+"connection_map": {
+    "1,2": "kafka1",
+    "*": "kafka1"
+}
+```
+
+- Records with a `standard:route` of `1` or `2` will go to topic `my-data-1` or `my-data-2` respectively
+- All other records will go to topic `my-data`
+
+```js
+"topic": "my-data",
+"connection_map": {
+    "1,2": "kafka1",
+    "**": "kafka1"
+}
+```
+
+- Records with a `standard:route` of `1` or `2` will go to topic `my-data-1` or `my-data-2` respectively
+- All other records will be dynamically sorted. Destination topics will be `my-data-${standard:route}` if `standard:route` is set on the record or `my-data` if it is not
+
 
 **Example Job Config:**
 

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "2.7.1"
+    "version": "2.8.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-assets",
-    "version": "2.7.1",
+    "version": "2.8.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "main": "index.js",

--- a/asset/src/_kafka_clients/interfaces.ts
+++ b/asset/src/_kafka_clients/interfaces.ts
@@ -25,6 +25,7 @@ export interface ConsumerClientConfig {
 }
 
 export interface ProduceMessage {
+    topic: string|null;
     data: Buffer;
     key: Buffer|string|null;
     timestamp: number|null;

--- a/asset/src/_kafka_clients/producer-client.ts
+++ b/asset/src/_kafka_clients/producer-client.ts
@@ -59,7 +59,7 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
                 const message: ProduceMessage = (map == null) ? msg : map(msg);
 
                 this._client.produce(
-                    this._topic,
+                    message.topic || this._topic,
                     // This is the partition. There may be use cases where
                     // we'll need to control this.
                     null,

--- a/asset/src/kafka_dead_letter/api.ts
+++ b/asset/src/kafka_dead_letter/api.ts
@@ -75,6 +75,7 @@ export default class KafkaDeadLetter extends OperationAPI<KafkaDeadLetterConfig>
                 timestamp: Date.now(),
                 data: Buffer.from(JSON.stringify(data)),
                 key: null,
+                topic: null
             };
 
             this.collector.add(msg);

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -52,7 +52,7 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
             this.hasConnectionMap = true;
             const keysets = Object.keys(connectionMap);
 
-            if (keysets.indexOf('*') > -1 && keysets.indexOf('**') > -1) throw new TSError('connectorMap cannot specify "*" and "**"');
+            if (keysets.includes('*') && keysets.includes('**')) throw new TSError('connectorMap cannot specify "*" and "**"');
 
             for (const keyset of keysets) {
                 const keys = keyset.split(',');

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -138,7 +138,7 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
                 const routeConfig = this.topicMap.get('*') as Endpoint;
                 routeConfig.data.push(record);
             } else if (this.connectorDict.has('**')) {
-                const routeTopic = `${this.opConfig.topic}-${route}`;
+                const routeTopic = route ? `${this.opConfig.topic}-${route}` : this.opConfig.topic;
                 if (!this.topicMap.has(routeTopic)) {
                     await this.createTopic('**', true, routeTopic);
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-asset-bundle",
-    "version": "2.7.1",
+    "version": "2.8.0",
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "private": true,
     "scripts": {

--- a/test/helpers/config.ts
+++ b/test/helpers/config.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 const {
-    KAFKA_BROKERS = '10.210.50.201:19092'
+    KAFKA_BROKERS = 'localhost:9092'
 } = process.env;
 
 export const kafkaBrokers: string[] = KAFKA_BROKERS.split(',').map((s) => s.trim());

--- a/test/helpers/config.ts
+++ b/test/helpers/config.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 const {
-    KAFKA_BROKERS = 'localhost:9092'
+    KAFKA_BROKERS = '10.210.50.201:19092'
 } = process.env;
 
 export const kafkaBrokers: string[] = KAFKA_BROKERS.split(',').map((s) => s.trim());

--- a/test/kafka-sender-spec.ts
+++ b/test/kafka-sender-spec.ts
@@ -291,18 +291,14 @@ describe('Kafka Sender', () => {
             let ogTopicMap: Map<string, any>;
 
             beforeAll(() => {
-                // @ts-ignore
                 ogTopicMap = sender.topicMap;
 
-                // @ts-ignore
                 sender.topicMap = new Map();
-                // Ensure '**' will not be in the topic map for this test
                 // @ts-ignore
                 sender.topicMap.set('*', {});
             });
 
             afterAll(() => {
-                // @ts-ignore
                 sender.topicMap = ogTopicMap;
             });
             it('returns null', () => {
@@ -312,7 +308,7 @@ describe('Kafka Sender', () => {
                     ip: '235.99.183.52',
                     url: 'http://bijupnag.cv/owi'
                 });
-                // @ts-ignore
+                //@ts-ignore
                 const routeTopic = sender.getRouteTopic(entity);
                 expect(routeTopic).toEqual(null);
             });
@@ -321,17 +317,14 @@ describe('Kafka Sender', () => {
             let ogTopicMap: Map<string, any>;
 
             beforeAll(() => {
-                // @ts-ignore
                 ogTopicMap = sender.topicMap;
 
-                // @ts-ignore
                 sender.topicMap = new Map();
                 // @ts-ignore
                 sender.topicMap.set('**', {});
             });
 
             afterAll(() => {
-                // @ts-ignore
                 sender.topicMap = ogTopicMap;
             });
             it('sets the topic based on the opConfig and the record\'s "standard:route"', () => {
@@ -343,7 +336,7 @@ describe('Kafka Sender', () => {
                 });
                 entity.setMetadata('standard:route', 'endor');
                 // @ts-ignore
-                const routeTopic = sender.getRouteTopic(entity);
+                const routeTopic = sender.getRouteTopic(entity, '**');
                 expect(routeTopic).toEqual('kafka-test-sender-endor');
             });
             it('sets the topic to default when missing record\'s "standard:route"', () => {
@@ -354,7 +347,7 @@ describe('Kafka Sender', () => {
                     url: 'http://bijupnag.cv/owi'
                 });
                 // @ts-ignore
-                const routeTopic = sender.getRouteTopic(entity);
+                const routeTopic = sender.getRouteTopic(entity, '**');
                 expect(routeTopic).toEqual('kafka-test-sender');
             });
         });

--- a/test/kafka-sender-spec.ts
+++ b/test/kafka-sender-spec.ts
@@ -308,7 +308,7 @@ describe('Kafka Sender', () => {
                     ip: '235.99.183.52',
                     url: 'http://bijupnag.cv/owi'
                 });
-                //@ts-ignore
+                // @ts-ignore
                 const routeTopic = sender.getRouteTopic(entity);
                 expect(routeTopic).toEqual(null);
             });

--- a/test/kafka-sender-spec.ts
+++ b/test/kafka-sender-spec.ts
@@ -286,6 +286,80 @@ describe('Kafka Sender', () => {
         });
     });
 
+    describe('->getRouteTopic', () => {
+        describe('when "**" is not in the topic map', () => {
+            let ogTopicMap: Map<string, any>;
+
+            beforeAll(() => {
+                // @ts-ignore
+                ogTopicMap = sender.topicMap;
+
+                // @ts-ignore
+                sender.topicMap = new Map();
+                // Ensure '**' will not be in the topic map for this test
+                // @ts-ignore
+                sender.topicMap.set('*', {});
+            });
+
+            afterAll(() => {
+                // @ts-ignore
+                sender.topicMap = ogTopicMap;
+            });
+            it('returns null', () => {
+                const entity = new DataEntity({
+                    id: '7dab1337-f786-5d1f-a18c-2735684efd3d',
+                    name: 'Luke Skywalker',
+                    ip: '235.99.183.52',
+                    url: 'http://bijupnag.cv/owi'
+                });
+                // @ts-ignore
+                const routeTopic = sender.getRouteTopic(entity);
+                expect(routeTopic).toEqual(null);
+            });
+        });
+        describe('when "**" is in the topic map', () => {
+            let ogTopicMap: Map<string, any>;
+
+            beforeAll(() => {
+                // @ts-ignore
+                ogTopicMap = sender.topicMap;
+
+                // @ts-ignore
+                sender.topicMap = new Map();
+                // @ts-ignore
+                sender.topicMap.set('**', {});
+            });
+
+            afterAll(() => {
+                // @ts-ignore
+                sender.topicMap = ogTopicMap;
+            });
+            it('sets the topic based on the opConfig and the record\'s "standard:route"', () => {
+                const entity = new DataEntity({
+                    id: '7dab1337-f786-5d1f-a18c-2735684efd3d',
+                    name: 'Luke Skywalker',
+                    ip: '235.99.183.52',
+                    url: 'http://bijupnag.cv/owi'
+                });
+                entity.setMetadata('standard:route', 'endor');
+                // @ts-ignore
+                const routeTopic = sender.getRouteTopic(entity);
+                expect(routeTopic).toEqual('kafka-test-sender-endor');
+            });
+            it('sets the topic to default when missing record\'s "standard:route"', () => {
+                const entity = new DataEntity({
+                    id: '7dab1337-f786-5d1f-a18c-2735684efd3d',
+                    name: 'Luke Skywalker',
+                    ip: '235.99.183.52',
+                    url: 'http://bijupnag.cv/owi'
+                });
+                // @ts-ignore
+                const routeTopic = sender.getRouteTopic(entity);
+                expect(routeTopic).toEqual('kafka-test-sender');
+            });
+        });
+    });
+
     describe('->getTimestamp', () => {
         describe('when timestamp_field is set', () => {
             let ogTimestampField: string;


### PR DESCRIPTION
refs #258 

Including `**` in the topic map will append the record's `standard:route` to the default topic and use that for the record's destination topic. If `standard:route` is not set, the default topic will be used for routing.