### PR TITLE
Update Kafka version to 3.3 from 3.2 in the test script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
         "setup": "yarn && yarn build",
-        "test": "KAFKA_VERSION=3.2 ts-scripts test . --",
+        "test": "KAFKA_VERSION=3.3 ts-scripts test . --",
         "test:all": "yarn workspaces run test",
         "test:watch": "ts-scripts test --watch . --",
         "test:debug": "ts-scripts test --debug . --",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -15,7 +15,7 @@
         "prepare": "yarn build",
         "build": "tsc --project ./tsconfig.json",
         "build:watch": "yarn build --watch",
-        "test": "KAFKA_VERSION=3.2 ts-scripts test . --",
+        "test": "KAFKA_VERSION=3.3 ts-scripts test . --",
         "test:watch": "ts-scripts test --watch . --",
         "test:debug": "ts-scripts test --debug . --"
     },


### PR DESCRIPTION
Update the Kafka-assets/package.json and /packages/terafoundation_kafka_connector/package.json files:

```
scripts: {
    tests: "KAFKA_VERSION=3.3 ts-scripts test . --"
```

CI tests on this repo were failing with Kafka version 3.2. 
Possible race condition?

```
Command failed with exit code 125: docker run --rm --publish 49092:49092 --env KAFKA_HEAP_OPTS=-Xms512m -Xmx512m --env KAFKA_AUTO_CREATE_TOPICS_ENABLE=true --env KAFKA_ADVERTISED_HOST_NAME=10.1.0.225 --env KAFKA_ADVERTISED_PORT=49092 --env KAFKA_PORT=49092 --env KAFKA_NUM_PARTITIONS=2 --tmpfs /tmp/kafka-logs --name ts_test_kafka blacktop/kafka:3.2
docker: Error response from daemon: Conflict. The container name "/ts_test_kafka" is already in use by container "02c2424930256ec8360cfea078d1180c5dcd2ade6bd58549c2eeef242161247f". You have to remove (or rename) that container to be able to reuse that name.
```

Hopefully 3.3 will eliminate the issue.