### PR TITLE
Jest types bump and test fixes

### DIFF
--- a/packages/terafoundation_kafka_connector/test/kafka-connector-spec.ts
+++ b/packages/terafoundation_kafka_connector/test/kafka-connector-spec.ts
@@ -156,7 +156,7 @@ describe('Kafka Connector', () => {
             expect(() => {
                 // @ts-expect-error
                 connector.create(config, logger, settings);
-            }).toThrowError('Unsupport client type of wrong');
+            }).toThrow('Unsupport client type of wrong');
         });
     });
 });

--- a/test/kafka_dead_letter/schema-spec.ts
+++ b/test/kafka_dead_letter/schema-spec.ts
@@ -16,7 +16,7 @@ describe('Kafka Dead Letter Schema', () => {
                 schema.validate({
                     _name: 'kafka_deader_letter'
                 });
-            }).toThrowError(/kafka_deader_letter - topic: This field is required and must by of type string/);
+            }).toThrow(/kafka_deader_letter - topic: This field is required and must by of type string/);
         });
 
         it('should not throw an error if valid config is given', () => {
@@ -25,7 +25,7 @@ describe('Kafka Dead Letter Schema', () => {
                     _name: 'kafka_deader_letter',
                     topic: 'hello'
                 });
-            }).not.toThrowError();
+            }).not.toThrow();
         });
     });
 });

--- a/test/kafka_reader/fetcher-spec.ts
+++ b/test/kafka_reader/fetcher-spec.ts
@@ -137,7 +137,7 @@ describe('Kafka Fetcher', () => {
 
         // @ts-expect-error
         // eslint-disable-next-line jest/no-standalone-expect
-        await expect(fetcher.consumer._beforeTry()).rejects.toThrowError('Client is closed');
+        await expect(fetcher.consumer._beforeTry()).rejects.toThrow('Client is closed');
 
         await harness.shutdown();
     });
@@ -150,7 +150,7 @@ describe('Kafka Fetcher', () => {
         expect(() => {
             // @ts-expect-error
             fetcher.consumer._clientEvents();
-        }).not.toThrowError();
+        }).not.toThrow();
 
         // @ts-expect-error
         const actual = fetcher.consumer._client.listenerCount('error');

--- a/test/kafka_reader/schema-spec.ts
+++ b/test/kafka_reader/schema-spec.ts
@@ -48,7 +48,7 @@ describe('Kafka Reader Schema', () => {
             });
             expect(() => {
                 schema.validateJob(job);
-            }).toThrowError('Kafka Reader handles serialization, please remove "json_protocol"');
+            }).toThrow('Kafka Reader handles serialization, please remove "json_protocol"');
         });
 
         it('should not throw if a valid job is given', () => {
@@ -66,7 +66,7 @@ describe('Kafka Reader Schema', () => {
             });
             expect(() => {
                 schema.validateJob(job);
-            }).not.toThrowError();
+            }).not.toThrow();
         });
 
         it('should inject an api if none is specified', () => {
@@ -90,7 +90,7 @@ describe('Kafka Reader Schema', () => {
 
                 expect(apiConfig._name.startsWith('kafka_reader_api')).toBeTrue();
                 expect(job.apis[0]).toMatchObject({ topic: 'hello', group: 'hi' });
-            }).not.toThrowError();
+            }).not.toThrow();
         });
 
         it('should throw if topic/group is specified differently in opConfig if api is set with api_name', () => {
@@ -112,7 +112,7 @@ describe('Kafka Reader Schema', () => {
             });
             expect(() => {
                 schema.validateJob(job);
-            }).toThrowError();
+            }).toThrow();
         });
 
         it('should associate with default kafka sender if no api_name is specified', () => {
@@ -131,7 +131,7 @@ describe('Kafka Reader Schema', () => {
             });
             expect(() => {
                 schema.validateJob(job);
-            }).not.toThrowError();
+            }).not.toThrow();
         });
 
         it('should associate with default kafka sender and throw if configs are incorrect', () => {
@@ -151,7 +151,7 @@ describe('Kafka Reader Schema', () => {
             });
             expect(() => {
                 schema.validateJob(job);
-            }).toThrowError();
+            }).toThrow();
         });
     });
 

--- a/test/kafka_sender/processor-spec.ts
+++ b/test/kafka_sender/processor-spec.ts
@@ -131,7 +131,7 @@ describe('Kafka Sender', () => {
             const testTopic = kafkaSender.api;
             // @ts-expect-error
             testTopic.producer._clientEvents();
-        }).not.toThrowError();
+        }).not.toThrow();
 
         const actualTopic = kafkaSender.api;
         // @ts-expect-error

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,9 +1063,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^29.5.3":
-  version "29.5.6"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.6.tgz#f4cf7ef1b5b0bfc1aa744e41b24d9cc52533130b"
-  integrity sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==
+  version "29.5.7"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.7.tgz#2c0dafe2715dd958a455bc10e2ec3e1ec47b5036"
+  integrity sha512-HLyetab6KVPSiF+7pFcUyMeLsx25LDNDemw9mGsJBkai/oouwrjTycocSDYopMEwFhN2Y4s9oPyOCZNofgSt2g==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -1098,9 +1098,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "20.8.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.9.tgz#646390b4fab269abce59c308fc286dcd818a2b08"
-  integrity sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==
+  version "20.8.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.10.tgz#a5448b895c753ae929c26ce85cab557c6d4a365e"
+  integrity sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
Update @types/jest from v29.5.6 to 29.5.7
Replace all instances of the deprecated `toThrowError()` function within tests with `toThrow()`.