### PR TITLE
Add prom metrics to kafka_fetcher and kafka_sender

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "4.0.0"
+    "version": "4.1.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -21,7 +21,8 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.74.1"
+        "@terascope/job-components": "^0.74.1",
+        "@terascope/types": "^0.17.1"
     },
     "devDependencies": {},
     "engines": {

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/asset/src/_kafka_clients/producer-client.ts
+++ b/asset/src/_kafka_clients/producer-client.ts
@@ -14,6 +14,7 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
 
     private readonly _bufferSize: number;
     private _hasClientEvents = false;
+    private _bytesProduced = 0;
 
     constructor(client: kafka.Producer, config: ProducerClientConfig) {
         super(client, config.topic, config.logger);
@@ -71,6 +72,7 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
             for (let i = 0; i < total; i++) {
                 const msg = messages[i];
                 const message: ProduceMessage = (map == null) ? msg : map(msg);
+                this._bytesProduced += Buffer.byteLength(message.data);
 
                 this._client.produce(
                     message.topic || this._topic,
@@ -127,5 +129,12 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
 
         // for event error logs.
         this._client.on('event.error', this._logOrEmit('client:error'));
+    }
+
+    /**
+     * Get the number of bytes producer has produced
+    */
+    async getBytesProduced() {
+        return this._bytesProduced;
     }
 }

--- a/asset/src/kafka_reader/fetcher.ts
+++ b/asset/src/kafka_reader/fetcher.ts
@@ -29,17 +29,16 @@ export default class KafkaFetcher extends Fetcher<KafkaReaderConfig> {
         this.consumeConfig = { size, wait };
         this.consumer = consumer;
 
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const self = this;
+        const { context } = this;
         await this.context.apis.foundation.promMetrics.addGauge(
             'partitions',
             'Number of partitions the Consumer is consuming from',
             ['class'],
             async function collect() {
-                const partitionCount = await self.consumer.getPartitionCount(topic);
+                const partitionCount = await consumer.getPartitionCount(topic);
                 const labels = {
                     class: 'KafkaFetcher',
-                    ...self.context.apis.foundation.promMetrics.getDefaultLabels()
+                    ...context.apis.foundation.promMetrics.getDefaultLabels()
                 };
                 this.set(labels, partitionCount);
             });
@@ -47,10 +46,10 @@ export default class KafkaFetcher extends Fetcher<KafkaReaderConfig> {
             'Number of bytes the Consumer has consumed',
             ['class'],
             async function collect() {
-                const bytesConsumed = await self.consumer.getBytesConsumed();
+                const bytesConsumed = await consumer.getBytesConsumed();
                 const labels = {
                     class: 'KafkaFetcher',
-                    ...self.context.apis.foundation.promMetrics.getDefaultLabels()
+                    ...context.apis.foundation.promMetrics.getDefaultLabels()
                 };
                 this.set(labels, bytesConsumed);
             });

--- a/asset/src/kafka_sender_api/api.ts
+++ b/asset/src/kafka_sender_api/api.ts
@@ -88,7 +88,11 @@ export default class KafkaSenderApi extends APIFactory<KafkaRouteSender, KafkaSe
 
         validConfig.tryFn = this.tryRecord.bind(this);
 
-        const client = new KafkaRouteSender(kafkaClient, validConfig);
+        const client = new KafkaRouteSender(
+            kafkaClient,
+            validConfig,
+            this.context.apis.foundation.promMetrics
+        );
 
         await client.initialize();
 

--- a/asset/src/kafka_sender_api/sender.ts
+++ b/asset/src/kafka_sender_api/sender.ts
@@ -54,17 +54,16 @@ export default class KafkaSender implements RouteSenderAPI {
     }
 
     async initialize(): Promise<void> {
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const self = this;
+        const { promMetrics, producer } = this;
         this.promMetrics.addGauge(
             'bytes_produced',
             'Number of bytes producer has produced',
             ['class'],
             async function collect() {
-                const bytesProduced = await self.producer.getBytesProduced();
+                const bytesProduced = await producer.getBytesProduced();
                 const labels = {
                     class: 'KafkaSender',
-                    ...self.promMetrics.getDefaultLabels()
+                    ...promMetrics.getDefaultLabels()
                 };
                 this.set(labels, bytesProduced);
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5763,7 +5763,14 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.6.1:
+semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.6.1:
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
   integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==


### PR DESCRIPTION
This PR makes the following changes:
- add `_bytesConsumed`, `getBytesConsumed()` and `getPartitionCount()` to `asset/src/_kafka_clients/consumer-client.ts`
- add `bytes_consumed` and `partitions` promMetric to `kafkaFetcher`
- add `_bytesProduced` and `getBytesProduced()` to `asset/src/_kafka_clients/producer-client.ts`
- add `bytes_produced` promMetric to `kafkaSender`