### PR TITLE
Add node 22 workflows

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@f6b34eb9b2ea5d113078381237ca81e5520e6f5b
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@73a80a9e19cde53baf8a918e2c7c69bf39ca884a
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@f6b34eb9b2ea5d113078381237ca81e5520e6f5b
+    uses: terascope/workflows/.github/workflows/asset-test.yml@73a80a9e19cde53baf8a918e2c7c69bf39ca884a
     secrets: inherit

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "4.2.0"
+    "version": "4.3.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "4.2.0",
+    "version": "4.3.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "4.2.0",
+    "version": "4.3.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "repository": "git@github.com:terascope/kafka-assets.git",


### PR DESCRIPTION
This PR makes the following changes:

- Updates github actions workflow that includes node `v22.2.0` 
- Bumps **kafka-assets** to `v4.3.0`