### PR TITLE
Revert "Bump node-rdkafka from 3.0.1 to 3.1.0"

### DIFF
--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -22,7 +22,7 @@
         "test:watch": "NODE_OPTIONS='--experimental-vm-modules' KAFKA_VERSION=3.2 ts-scripts test --watch . --"
     },
     "dependencies": {
-        "node-rdkafka": "^3.1.0"
+        "node-rdkafka": "^3.0.1"
     },
     "devDependencies": {
         "@terascope/job-components": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4907,10 +4907,10 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-rdkafka@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.1.0.tgz#b2646ef7200d947516045f5ed19cb609a98891fa"
-  integrity sha512-H0FeV6cgkFX/NHKPyWsUHoC4l645/2vfKVdTyvKmwX+nafHuZzT6xVWl2kJQBNVJcRVgtQA1Loz6iXWhq03RKw==
+node-rdkafka@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.0.1.tgz#c536d7702d971535b41099acc1baf89706a5d1ba"
+  integrity sha512-USTFu7ylRj+fEiGz0hA92GWSqmX/hu/xSTqtgmInPPmh5zKhjauTciRjDEG3yK5m6yChwyHKQTIgmr56DfhiaQ==
   dependencies:
     bindings "^1.3.1"
     nan "^2.19.0"


### PR DESCRIPTION
Reverts terascope/kafka-assets#813

See issues:
https://github.com/Blizzard/node-rdkafka/issues/1087
https://github.com/confluentinc/librdkafka/issues/4793