### PR TITLE
Test on default kafka version from scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
         "@terascope/job-components": "^1.1.0",
-        "@terascope/scripts": "^0.83.1",
+        "@terascope/scripts": "^0.83.2",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.9",
         "@types/uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
         "lint:fix": "yarn lint --fix",
         "publish:changed": "./scripts/publish.sh",
         "setup": "yarn && yarn build --force",
-        "test": "NODE_OPTIONS='--experimental-vm-modules' KAFKA_VERSION=3.2 ts-scripts test asset --",
-        "test:all": "NODE_OPTIONS='--experimental-vm-modules' KAFKA_VERSION=3.2 ts-scripts test",
-        "test:debug": "NODE_OPTIONS='--experimental-vm-modules' KAFKA_VERSION=3.2 ts-scripts test --debug asset --",
-        "test:watch": "NODE_OPTIONS='--experimental-vm-modules' KAFKA_VERSION=3.2 ts-scripts test --watch asset --"
+        "test": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test asset --",
+        "test:all": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test",
+        "test:debug": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test --debug asset --",
+        "test:watch": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test --watch asset --"
     },
     "dependencies": {
         "node-gyp": "10.2.0"

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -17,9 +17,9 @@
         "build": "tsc --project ./tsconfig.json",
         "build:watch": "yarn build --watch",
         "prepare": "yarn build",
-        "test": "NODE_OPTIONS='--experimental-vm-modules' KAFKA_VERSION=3.2 ts-scripts test . --",
-        "test:debug": "NODE_OPTIONS='--experimental-vm-modules' KAFKA_VERSION=3.2 ts-scripts test --debug . --",
-        "test:watch": "NODE_OPTIONS='--experimental-vm-modules' KAFKA_VERSION=3.2 ts-scripts test --watch . --"
+        "test": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test . --",
+        "test:debug": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test --debug . --",
+        "test:watch": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test --watch . --"
     },
     "dependencies": {
         "node-rdkafka": "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,10 +754,10 @@
     prom-client "^15.1.2"
     uuid "^9.0.1"
 
-"@terascope/scripts@^0.83.1":
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.83.1.tgz#81b0d2af4dea305e6c0edfe2ca4a744a2c5d1a56"
-  integrity sha512-mpc56rMFD1yk8yQdgK4uCs4Rz51Um27K3K5BzyzZpCc0PR/myGBWscexl2COj38nzqOb9N1AX7fLiqU3AECT8A==
+"@terascope/scripts@^0.83.2":
+  version "0.83.2"
+  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.83.2.tgz#77411555ab8b6ff405911e4112df5a90f05dcf66"
+  integrity sha512-9NlXQYzQ4wZufS/l5UyrYHxZ0RbJkkOAq0kGE6z2huQ0gYo3RQFi18GNlJfeLIjiWN3yn58Kz+jvUv/6vy3HXw==
   dependencies:
     "@kubernetes/client-node" "^0.20.0"
     "@terascope/utils" "^0.60.0"


### PR DESCRIPTION
This PR makes the following changes:
- Update `ts-scripts` from 0.83.1 to 0.83.2
- Remove `KAFKA_VERSION=3.2` from all test scripts. This results in the kafka version being set to the default version in `ts-scripts`. The current version is 3.5.