### PR TITLE
[Kafka-asset] Allow kafka to be relocatable

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.0.2"
+    "version": "5.1.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.0.2",
+    "version": "5.1.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/asset/src/kafka_reader/slicer.ts
+++ b/asset/src/kafka_reader/slicer.ts
@@ -6,6 +6,10 @@ export default class KafkaSlicer extends Slicer<KafkaReaderConfig> {
         return Boolean(this.executionConfig.autorecover);
     }
 
+    isRestartable(): boolean {
+        return true;
+    }
+
     maxQueueLength(): number {
         return this.workersConnected + 1;
     }

--- a/asset/src/kafka_reader/slicer.ts
+++ b/asset/src/kafka_reader/slicer.ts
@@ -6,7 +6,7 @@ export default class KafkaSlicer extends Slicer<KafkaReaderConfig> {
         return Boolean(this.executionConfig.autorecover);
     }
 
-    isRestartable(): boolean {
+    isRelocatable(): boolean {
         return true;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.0.2",
+    "version": "5.1.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "repository": "git@github.com:terascope/kafka-assets.git",


### PR DESCRIPTION
This PR makes the following changes:

## New Features 

- Operation `kafka_reader` is now relocatable when running in `kubernetesV2` in teraslice
  - This slicer is able to come back up in the event the pod is deleted in kubernetes. This includes use cases such as draining a node which would delete all resources from that node.