### PR TITLE
Fix Kafka producer queue full bug

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.1.0"
+    "version": "5.2.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.1.0",
+    "version": "5.2.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/asset/src/_kafka_clients/interfaces.ts
+++ b/asset/src/_kafka_clients/interfaces.ts
@@ -39,7 +39,8 @@ export interface ProduceMessage {
 export interface ProducerClientConfig {
     topic: string;
     logger: Logger;
-    bufferSize: number;
+    maxBufferLength: number;
+    maxBufferKilobyteSize: number;
 }
 
 export interface FatalError extends Error {

--- a/asset/src/_kafka_clients/producer-client.ts
+++ b/asset/src/_kafka_clients/producer-client.ts
@@ -70,9 +70,9 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
         let currentBatchSizeInBytes = 0;
         const maxQueueByteSize = this._maxBufferKilobyteSize * 1024;
         if (this._maxBufferMsgLength > 0) {
-            this._logger.debug(`producing ${total} messages in batches ${Math.floor(total / this._maxBufferMsgLength)}...`);
+            this._logger.debug(`Kafka producing ${total} messages in ${Math.floor(total / this._maxBufferMsgLength)} batches...`);
         } else {
-            this._logger.debug(`producing ${total} messages in 1 batch`);
+            this._logger.debug(`Kafka producing ${total} messages in 1 batch...`);
         }
 
         try {
@@ -88,7 +88,7 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
                 // If the current queue batch kb size gets full, do a flush.
                 if (currentBatchSizeInBytes >= maxQueueByteSize) {
                     this._logger.warn(
-                        `Producer queue size exceeded limit: max_buffer_kbytes_size = ${this._maxBufferKilobyteSize} KB, `
+                        `Kafka producer queue size exceeded limit: max_buffer_kbytes_size = ${this._maxBufferKilobyteSize} KB, `
                         + `Current batch size = ${currentBatchSizeInBytes / 1024} KB. Initiating queue flush to prevent overflow...`
                     );
 
@@ -109,7 +109,7 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
                 // flush the messages at the end of each slice
                 if (i === endOfSliceIndex) {
                     this._logger.debug(
-                        `End of message batch reached: Flushing the queue after processing ${total} messages. `
+                        `End of message slice reached: Flushing the queue after processing ${total} messages. `
                     );
                     await this._try(() => this._flush(), 'produce', 0);
                     currentBatchSizeInBytes = 0; // Reset the batch size counter
@@ -122,7 +122,7 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
                     && i % this._maxBufferMsgLength === endofBufferIndex
                 ) {
                     this._logger.debug(
-                        `Producer max_buffer_size of ${this._maxBufferMsgLength} has been met, flushing queue to start new batch...`
+                        `Kafka producer max_buffer_size of ${this._maxBufferMsgLength} has been met, flushing queue to start new batch...`
                     );
                     await this._try(() => this._flush(), 'produce', 0);
                     currentBatchSizeInBytes = 0;

--- a/asset/src/_kafka_clients/producer-client.ts
+++ b/asset/src/_kafka_clients/producer-client.ts
@@ -101,9 +101,11 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
                 // flush the messages at the end of each slice
                 if (i === endOfBatchIndex) {
                     await this._try(() => this._flush(), 'produce', 0);
+                    this._logger.debug(`End of message batch Flushing queue before writing more messages...`);
                     currentBatchSizeInBytes = 0; // Reset the batch size counter
                 // OR at the first message
                 } else if (i % this._maxBufferMsgLength === endofBufferIndex) {
+                    this._logger.debug(`Beginning of message batch Flushing queue before writing more messages...`);
                     await this._try(() => this._flush(), 'produce', 0);
                     currentBatchSizeInBytes = 0;
                 }

--- a/asset/src/_kafka_clients/producer-client.ts
+++ b/asset/src/_kafka_clients/producer-client.ts
@@ -64,7 +64,7 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
         });
 
         const total = messages.length;
-        const endOfBatchIndex = (total - 1);
+        const endOfSliceIndex = (total - 1);
         const endofBufferIndex = (this._maxBufferMsgLength - 1);
         // This is a counter that will track the bytes written in the current batch
         let currentBatchSizeInBytes = 0;
@@ -107,7 +107,7 @@ export default class ProducerClient extends BaseClient<kafka.Producer> {
                 );
 
                 // flush the messages at the end of each slice
-                if (i === endOfBatchIndex) {
+                if (i === endOfSliceIndex) {
                     this._logger.debug(
                         `End of message batch reached: Flushing the queue after processing ${total} messages. `
                     );

--- a/asset/src/kafka_dead_letter/api.ts
+++ b/asset/src/kafka_dead_letter/api.ts
@@ -22,7 +22,8 @@ export default class KafkaDeadLetter extends OperationAPI<KafkaDeadLetterConfig>
         this.producer = new ProducerClient(client, {
             logger,
             topic: this.apiConfig.topic,
-            bufferSize: this.apiConfig.max_buffer_size,
+            maxBufferLength: this.apiConfig.max_buffer_size,
+            maxBufferKilobyteSize: this.apiConfig.max_buffer_kbytes_size
         });
 
         this.collector = new Collector({

--- a/asset/src/kafka_dead_letter/interfaces.ts
+++ b/asset/src/kafka_dead_letter/interfaces.ts
@@ -26,6 +26,10 @@ export interface KafkaDeadLetterConfig extends APIConfig {
     */
     max_buffer_size: number;
     /**
+     Maximum total message size sum in kilobytes allowed on the producer queue.
+    */
+    max_buffer_kbytes_size: number;
+    /**
      How often the producer will poll the broker for metadata information.
      Set to -1 to disable polling.
     */

--- a/asset/src/kafka_dead_letter/schema.ts
+++ b/asset/src/kafka_dead_letter/schema.ts
@@ -34,6 +34,11 @@ export default class Schema extends ConvictSchema<KafkaDeadLetterConfig> {
                 default: 100000,
                 format: Number
             },
+            max_buffer_kbytes_size: {
+                doc: 'Maximum total message size sum in kilobytes allowed on the producer queue.',
+                default: 1048576,
+                format: Number
+            },
             metadata_refresh: {
                 doc: 'How often the producer will poll the broker for metadata information. Set to -1 to disable polling.',
                 default: 300000,

--- a/asset/src/kafka_sender_api/api.ts
+++ b/asset/src/kafka_sender_api/api.ts
@@ -45,6 +45,7 @@ export default class KafkaSenderApi extends APIFactory<KafkaRouteSender, KafkaSe
             },
             rdkafka_options: {
                 'compression.codec': kafkaConfig.compression,
+                'queue.buffering.max.kbytes': kafkaConfig.max_buffer_kbytes_size,
                 'queue.buffering.max.messages': kafkaConfig.max_buffer_size,
                 'queue.buffering.max.ms': kafkaConfig.wait,
                 'batch.num.messages': kafkaConfig.size,

--- a/asset/src/kafka_sender_api/api.ts
+++ b/asset/src/kafka_sender_api/api.ts
@@ -32,7 +32,7 @@ export default class KafkaSenderApi extends APIFactory<KafkaRouteSender, KafkaSe
         // maxBufferLength is used as an indicator of when to flush the queue in producer-client.ts
         // in addition to the max.messages setting
         config.maxBufferLength = config.max_buffer_size;
-        // maxBufferKilobyteSize is also used as an indicator of when to flush the queue in producer-client.ts
+        // maxBufferKilobyteSize is also used as an indicator of when to flush the queue
         config.maxBufferKilobyteSize = config.max_buffer_kbytes_size;
 
         return config;

--- a/asset/src/kafka_sender_api/api.ts
+++ b/asset/src/kafka_sender_api/api.ts
@@ -29,9 +29,12 @@ export default class KafkaSenderApi extends APIFactory<KafkaRouteSender, KafkaSe
         if (isNil(config.required_acks) || !isNumber(config.required_acks)) throw new Error(`Parameter required_acks must be provided and be of type number, got ${getTypeOf(config.required_acks)}`);
         if (isNil(config.logger)) throw new Error(`Parameter logger must be provided and be of type Logger, got ${getTypeOf(config.logger)}`);
 
-        // bufferSize is used as an indicator of when to flush the queue in producer-client.ts
+        // maxBufferLength is used as an indicator of when to flush the queue in producer-client.ts
         // in addition to the max.messages setting
-        config.bufferSize = config.max_buffer_size;
+        config.maxBufferLength = config.max_buffer_size;
+        // maxBufferKilobyteSize is also used as an indicator of when to flush the queue in producer-client.ts
+        config.maxBufferKilobyteSize = config.max_buffer_kbytes_size;
+
         return config;
     }
 

--- a/asset/src/kafka_sender_api/schema.ts
+++ b/asset/src/kafka_sender_api/schema.ts
@@ -55,13 +55,24 @@ export const schema = {
         }
     },
     max_buffer_size: {
-        doc: 'Maximum number of messages allowed on the producer queue',
+        doc: 'Maximum number of messages allowed on the producer queue. A value of 0 disables this limit.',
         default: 100000,
         format: (val: unknown): void => {
             if (isNumber(val)) {
-                if (val <= 0) throw new Error('Invalid parameter max_buffer_size, it must be a positive number');
+                if (val < 0) throw new Error('Invalid parameter max_buffer_size, it must be a positive number');
             } else {
                 throw new Error(`Invalid parameter max_buffer_size, it must be a number, got ${getTypeOf(val)}`);
+            }
+        }
+    },
+    max_buffer_kbytes_size: {
+        doc: 'Maximum total message size sum in kilobytes allowed on the producer queue.',
+        default: 1048576,
+        format: (val: unknown): void => {
+            if (isNumber(val)) {
+                if (val <= 0) throw new Error('Invalid parameter max_buffer_kbytes_size, it must be a positive number');
+            } else {
+                throw new Error(`Invalid parameter max_buffer_kbytes_size, it must be a number, got ${getTypeOf(val)}`);
             }
         }
     },

--- a/asset/src/kafka_sender_api/schema.ts
+++ b/asset/src/kafka_sender_api/schema.ts
@@ -59,7 +59,7 @@ export const schema = {
         default: 100000,
         format: (val: unknown): void => {
             if (isNumber(val)) {
-                if (val < 0) throw new Error('Invalid parameter max_buffer_size, it must be a positive number');
+                if (val < 0) throw new Error('Invalid parameter max_buffer_size, it must be a positive number, or 0');
             } else {
                 throw new Error(`Invalid parameter max_buffer_size, it must be a number, got ${getTypeOf(val)}`);
             }

--- a/asset/src/kafka_sender_api/sender.ts
+++ b/asset/src/kafka_sender_api/sender.ts
@@ -30,7 +30,8 @@ export default class KafkaSender implements RouteSenderAPI {
         const producer = new ProducerClient(client, {
             logger: config.logger,
             topic: config.topicOverride || config.topic,
-            bufferSize: config.bufferSize,
+            maxBufferLength: config.max_buffer_size,
+            maxBufferKilobyteSize: config.max_buffer_kbytes_size
         });
 
         this.config = config;

--- a/docs/apis/kafka_sender_api.md
+++ b/docs/apis/kafka_sender_api.md
@@ -195,7 +195,8 @@ await api.send([
 | \_op| Name of operation, it must reflect the exact name of the file | String | required |
 | topic | Name of the Kafka topic to send records | String | required |
 | size | How many messages will be batched and sent to kafka together. | Number | optional, defaults to `10,000` |
-| max_batch_size | Maximum number of messages allowed on the producer queue | Number | optional, defaults to `100,000` |
+| max_buffer_size | Maximum number of messages allowed on the producer queue. A value of 0 disables this limit. | Number | optional, defaults to `100,000` |
+| max_buffer_kbytes_size | Maximum total message size sum in kilobytes allowed on the producer queue. | Number | optional, defaults to `1,048,576` |
 | id_field | Field in the incoming record that will be used to assign the record to a topic partition. | String | optional, if not set, it will check for the `_key` metadata value. If no key is found the sender uses a round robin method to assign records to partitions.|
 | timestamp_field | Field in the incoming record that contains a timestamp to set on the record | String | optional, it will take precedence over `timestamp_now` if this is set |
 | timestamp_now | Set to true to have a timestamp generated as records are added to the topic | Boolean | optional, defaults to `false` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.1.0",
+    "version": "5.2.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/test/helpers/kafka-data.ts
+++ b/test/helpers/kafka-data.ts
@@ -41,7 +41,8 @@ export async function loadData(topic: string, fileName: string): Promise<Record<
     const client = new ProducerClient(producer, {
         logger,
         topic,
-        bufferSize: messages.length
+        maxBufferLength: messages.length,
+        maxBufferKilobyteSize: 1048576
     });
 
     await client.connect();


### PR DESCRIPTION
This PR makes the following changes:

- Adds new operations config to the `kafka_sender_api` called `max_buffer_kbytes_size` that allows the user to set the total message size sum in kilobytes allowed on the producer queue.
- Adds new logic to the kafka producer that will prevent an error in the case that the queue byte size is reached.
- Fixes false information in the `kafka_sender_api` to be correct
- Updates docs
- Adds logging to producer flush() actions 
- Bumps `kafka-assets` from `v5.1.0` to `v5.2.0`

Ref to issue  #755