### PR TITLE
Dependency updates 2024-11-12

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.1.0"
+    "version": "5.2.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.1.0",
+    "version": "5.2.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "devDependencies": {
         "@terascope/eslint-config": "^1.1.0",
         "@terascope/job-components": "^1.5.3",
-        "@terascope/scripts": "^1.4.2",
+        "@terascope/scripts": "^1.5.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "^22.5.4",
+        "@types/node": "^22.9.0",
         "@types/uuid": "^10.0.0",
         "bunyan": "^1.8.15",
         "eslint": "^9.14.0",
@@ -50,7 +50,7 @@
         "teraslice-test-harness": "^1.2.0",
         "ts-jest": "^29.2.5",
         "typescript": "~5.2.2",
-        "uuid": "^11.0.2"
+        "uuid": "^11.0.3"
     },
     "engines": {
         "node": ">=18.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.1.0",
+    "version": "5.2.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "repository": "git@github.com:terascope/kafka-assets.git",
@@ -46,7 +46,7 @@
         "eslint": "^9.14.0",
         "jest": "^29.6.2",
         "jest-extended": "^4.0.2",
-        "terafoundation_kafka_connector": "^1.0.1",
+        "terafoundation_kafka_connector": "^1.1.0",
         "teraslice-test-harness": "^1.2.0",
         "ts-jest": "^29.2.5",
         "typescript": "~5.2.2",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation_kafka_connector",
     "displayName": "Terafoundation Kafka Connector",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "homepage": "https://github.com/terascope/kafka-assets",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -22,7 +22,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "node-rdkafka": "^3.0.1"
+        "node-rdkafka": "^3.1.1"
     },
     "devDependencies": {
         "@terascope/job-components": "^1.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,10 +888,10 @@
     prom-client "^15.1.3"
     uuid "^10.0.0"
 
-"@terascope/scripts@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-1.4.2.tgz#1b9efe4c8418d32626760f3118377f54ec24b155"
-  integrity sha512-h++D7VOe9w+D+k7c4DCitjfybqiJruOAu9yAt1PYZV0B9jvUdd7+DQ6KMk2WjtsML3GkDZJbGe2BQAUWPcORXA==
+"@terascope/scripts@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-1.5.0.tgz#474127ce9152c465cc40a8273177146bea880ec8"
+  integrity sha512-IHrVWsd8qx9yUdMomjVbbjb7d8BUZZjQQv3BeQ57MTza9Ic+Zn2GseNTNATgpaHxRHCz3YZbRsoZ24Q7zjf0Yw==
   dependencies:
     "@kubernetes/client-node" "^0.22.0"
     "@terascope/utils" "^1.3.2"
@@ -1336,12 +1336,12 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^22.5.4":
-  version "22.5.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.4.tgz#83f7d1f65bc2ed223bdbf57c7884f1d5a4fa84e8"
-  integrity sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==
+"@types/node@^22.9.0":
+  version "22.9.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.0.tgz#b7f16e5c3384788542c72dc3d561a7ceae2c0365"
+  integrity sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.19.8"
 
 "@types/request@^2.47.1":
   version "2.48.12"
@@ -5259,10 +5259,10 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-rdkafka@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.0.1.tgz#c536d7702d971535b41099acc1baf89706a5d1ba"
-  integrity sha512-USTFu7ylRj+fEiGz0hA92GWSqmX/hu/xSTqtgmInPPmh5zKhjauTciRjDEG3yK5m6yChwyHKQTIgmr56DfhiaQ==
+node-rdkafka@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.1.1.tgz#2739fa70185f28c253555bd3b457cfc448d47ce1"
+  integrity sha512-3rY24KlFvkQ0Pfqo5HP/fXa1GA+8R7hFLP+rm2htT7XJluH2lJ1fcEM5KDWKpkq1Nf4otHYvnBdY5eRH6ecYjg==
   dependencies:
     bindings "^1.3.1"
     nan "^2.19.0"
@@ -6858,7 +6858,7 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
-undici-types@~6.19.2:
+undici-types@~6.19.2, undici-types@~6.19.8:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
@@ -6924,10 +6924,10 @@ uuid@^10.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
-uuid@^11.0.2:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.2.tgz#a8d68ba7347d051e7ea716cc8dcbbab634d66875"
-  integrity sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==
+uuid@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.3.tgz#248451cac9d1a4a4128033e765d137e2b2c49a3d"
+  integrity sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==
 
 uuid@^3.3.2:
   version "3.4.0"


### PR DESCRIPTION
This PR makes the following changes:
- terafoundation_kafka_connector: 
  - bump node-rdkafka from 3.0.1 to 3.1.1
  - This gets us past the issue with building node-rdkafa@3.1.0 on mac (#818)
  - bump version from 1.0.1 to 1.1.0
- kafka-asset-bundle:
  - bump @terascope/scripts from 1.4.2 to 1.5.0
  - bump @types/node from 22.5.4 to 22.9.0
  - bump uuid from 11.0.2 to 11.0.3
  - bump version from 5.1.0 to 5.2.0
- kafka-assets:
  - bump asset version from 5.1.0 to 5.2.0 