### PR TITLE
update node-rdkafka from v3.2.0 to v3.2.1

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.3.0"
+    "version": "5.3.1"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.3.0",
+    "version": "5.3.1",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.3.0",
+    "version": "5.3.1",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "repository": "git@github.com:terascope/kafka-assets.git",
@@ -46,7 +46,7 @@
         "eslint": "~9.15.0",
         "jest": "~29.7.0",
         "jest-extended": "~4.0.2",
-        "terafoundation_kafka_connector": "~1.2.0",
+        "terafoundation_kafka_connector": "~1.2.1",
         "teraslice-test-harness": "~1.2.1",
         "ts-jest": "~29.2.5",
         "typescript": "~5.2.2",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation_kafka_connector",
     "displayName": "Terafoundation Kafka Connector",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "homepage": "https://github.com/terascope/kafka-assets",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -22,7 +22,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "node-rdkafka": "~3.2.0"
+        "node-rdkafka": "~3.2.1"
     },
     "devDependencies": {
         "@terascope/job-components": "~1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5270,10 +5270,10 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-rdkafka@~3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.2.0.tgz#05d35a200275a08e5abc4540503c830af46f5228"
-  integrity sha512-Xt30tiwTKv6LXLtelNDXYETb1VnrzPU5s5OAeyY6fz20Bpqy5ARDoWKim4zsKugGlaztsmzPauqMYcQrLdk8HQ==
+node-rdkafka@~3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.2.1.tgz#1e41ed61e88c551745ca9de097c9e64a7cb1803d"
+  integrity sha512-lf/U8LLCLA8v2tAh2x4guizfFAZSt/KJSzzaIEXtYGospfeZVf2U0RfHlCo7+XvbUoAG4V3uyMgif/tjHQIYfA==
   dependencies:
     bindings "^1.3.1"
     nan "^2.19.0"


### PR DESCRIPTION
This PR makes the following changes:
- bump node-rdkafka from v3.2.0 to v3.2.1, which in turn bumps librdkafka from v2.6.0 to 2.6.1 
- bump terafoundation_kafka_connector from v1.2.0 to v1.2.1
- bump kafka-assets from v5.3.0 to v5.3.1

https://github.com/confluentinc/librdkafka/releases/tag/v2.6.1