### PR TITLE
Ensure npm publish is marked as latest

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -26,8 +26,7 @@ publish() {
         echo "$name@$currentVersion -> $targetVersion"
 
         if [ "$dryRun" == "false" ]; then
-            yarn npm publish \
-                --tag "$tag"
+            yarn npm publish
         fi
     else
         echo "Not publishing:"


### PR DESCRIPTION
This PR makes the following changes:

- Fix bump script to ensure npm packages are marked as latest