### PR TITLE
bundled dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,23 +33,23 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "dependencies": {
-        "node-gyp": "11.0.0"
+        "node-gyp": "11.1.0"
     },
     "devDependencies": {
         "@terascope/eslint-config": "~1.1.5",
         "@terascope/job-components": "~1.9.3",
-        "@terascope/scripts": "~1.10.0",
+        "@terascope/scripts": "~1.10.1",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~29.5.14",
-        "@types/node": "~22.13.0",
+        "@types/node": "~22.13.1",
         "@types/semver": "~7.5.8",
         "@types/uuid": "~10.0.0",
         "bunyan": "~1.8.15",
-        "eslint": "~9.19.0",
+        "eslint": "~9.20.0",
         "fs-extra": "~11.3.0",
         "jest": "~29.7.0",
         "jest-extended": "~4.0.2",
-        "semver": "~7.7.0",
+        "semver": "~7.7.1",
         "terafoundation_kafka_connector": "~1.2.1",
         "teraslice-test-harness": "~1.3.2",
         "ts-jest": "~29.2.5",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,6 @@
         "test:debug": "ts-scripts test --debug asset --",
         "test:watch": "ts-scripts test --watch asset --"
     },
-    "resolutions": {
-        "node-gyp": "11.1.0"
-    },
-    "dependencies": {
-        "node-gyp": "11.1.0"
-    },
     "devDependencies": {
         "@terascope/eslint-config": "~1.1.5",
         "@terascope/job-components": "~1.9.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
         "test:debug": "ts-scripts test --debug asset --",
         "test:watch": "ts-scripts test --watch asset --"
     },
+    "resolutions": {
+        "node-gyp": "11.1.0"
+    },
     "dependencies": {
         "node-gyp": "11.1.0"
     },

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -26,7 +26,7 @@
     },
     "devDependencies": {
         "@terascope/job-components": "~1.9.3",
-        "@terascope/scripts": "~1.10.0",
+        "@terascope/scripts": "~1.10.1",
         "@types/convict": "~6.1.6",
         "convict": "~6.2.4"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,6 +450,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/core@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@eslint/core@npm:0.11.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/1e0671d035c908175f445864a7864cf6c6a8b67a5dfba8c47b2ac91e2d3ed36e8c1f2fd81d98a73264f8677055559699d4adb0f97d86588e616fc0dc9a4b86c9
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^3.2.0":
   version: 3.2.0
   resolution: "@eslint/eslintrc@npm:3.2.0"
@@ -474,10 +483,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.19.0":
-  version: 9.19.0
-  resolution: "@eslint/js@npm:9.19.0"
-  checksum: 10c0/45dc544c8803984f80a438b47a8e578fae4f6e15bc8478a703827aaf05e21380b42a43560374ce4dad0d5cb6349e17430fc9ce1686fed2efe5d1ff117939ff90
+"@eslint/js@npm:9.20.0":
+  version: 9.20.0
+  resolution: "@eslint/js@npm:9.20.0"
+  checksum: 10c0/10e7b5b9e628b5192e8fc6b0ecd27cf48322947e83e999ff60f9f9e44ac8d499138bcb9383cbfa6e51e780d53b4e76ccc2d1753b108b7173b8404fd484d37328
   languageName: node
   linkType: hard
 
@@ -1161,9 +1170,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.10.0":
-  version: 1.10.0
-  resolution: "@terascope/scripts@npm:1.10.0"
+"@terascope/scripts@npm:~1.10.1":
+  version: 1.10.1
+  resolution: "@terascope/scripts@npm:1.10.1"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
     "@terascope/utils": "npm:~1.7.3"
@@ -1180,7 +1189,7 @@ __metadata:
     ms: "npm:~2.1.3"
     package-json: "npm:~10.0.1"
     package-up: "npm:~5.0.0"
-    semver: "npm:~7.6.3"
+    semver: "npm:~7.7.0"
     signale: "npm:~1.4.0"
     sort-package-json: "npm:~2.14.0"
     toposort: "npm:~2.0.2"
@@ -1194,7 +1203,7 @@ __metadata:
       optional: true
   bin:
     ts-scripts: ./bin/ts-scripts.js
-  checksum: 10c0/47c7e9bfe360e0d026c25fc5e936925e0267662d4734bd9f64e2b182e4d284b444593e776d1a5396203e19761baadc9f70b28b76d5808a0dc71cea22a518a184
+  checksum: 10c0/481afc328683607ad3d99dfce06e130298ee324b58087bcccfa023ca4dc3174bd295a1e4cc341cf387617b3656843d9fc39d53bc749077ac4482fae2acdbbd42
   languageName: node
   linkType: hard
 
@@ -1695,12 +1704,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~22.13.0":
-  version: 22.13.0
-  resolution: "@types/node@npm:22.13.0"
+"@types/node@npm:~22.13.1":
+  version: 22.13.1
+  resolution: "@types/node@npm:22.13.1"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10c0/9cf6358b2863ae7bf9588ca1cc3d87f6a6289c3880e95a046a188760666870e2c12502df8b0a473bec8aa8ffee85e025d60382a6104b10f197120793235b2c22
+  checksum: 10c0/d4e56d41d8bd53de93da2651c0a0234e330bd7b1b6d071b1a94bd3b5ee2d9f387519e739c52a15c1faa4fb9d97e825b848421af4b2e50e6518011e7adb4a34b7
   languageName: node
   linkType: hard
 
@@ -3700,16 +3709,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:~9.19.0":
-  version: 9.19.0
-  resolution: "eslint@npm:9.19.0"
+"eslint@npm:~9.20.0":
+  version: 9.20.0
+  resolution: "eslint@npm:9.20.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.19.0"
-    "@eslint/core": "npm:^0.10.0"
+    "@eslint/core": "npm:^0.11.0"
     "@eslint/eslintrc": "npm:^3.2.0"
-    "@eslint/js": "npm:9.19.0"
+    "@eslint/js": "npm:9.20.0"
     "@eslint/plugin-kit": "npm:^0.2.5"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
@@ -3745,7 +3754,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/3b0dfaeff6a831de086884a3e2432f18468fe37c69f35e1a0a9a2833d9994a65b6dd2a524aaee28f361c849035ad9d15e3841029b67d261d0abd62c7de6d51f5
+  checksum: 10c0/5eb2d9b5ed85a0b022871d19719417d110afb07a4abfedd856ad03d9a821def5f6bc31d7c407ca27f56e5e66e39375300fd2b877017245eb99c44060d6c983bd
   languageName: node
   linkType: hard
 
@@ -6011,19 +6020,19 @@ __metadata:
   dependencies:
     "@terascope/eslint-config": "npm:~1.1.5"
     "@terascope/job-components": "npm:~1.9.3"
-    "@terascope/scripts": "npm:~1.10.0"
+    "@terascope/scripts": "npm:~1.10.1"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~29.5.14"
-    "@types/node": "npm:~22.13.0"
+    "@types/node": "npm:~22.13.1"
     "@types/semver": "npm:~7.5.8"
     "@types/uuid": "npm:~10.0.0"
     bunyan: "npm:~1.8.15"
-    eslint: "npm:~9.19.0"
+    eslint: "npm:~9.20.0"
     fs-extra: "npm:~11.3.0"
     jest: "npm:~29.7.0"
     jest-extended: "npm:~4.0.2"
-    node-gyp: "npm:11.0.0"
-    semver: "npm:~7.7.0"
+    node-gyp: "npm:11.1.0"
+    semver: "npm:~7.7.1"
     terafoundation_kafka_connector: "npm:~1.2.1"
     teraslice-test-harness: "npm:~1.3.2"
     ts-jest: "npm:~29.2.5"
@@ -6607,7 +6616,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:11.0.0, node-gyp@npm:latest":
+"node-gyp@npm:11.1.0":
+  version: 11.1.0
+  resolution: "node-gyp@npm:11.1.0"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    glob: "npm:^10.3.10"
+    graceful-fs: "npm:^4.2.6"
+    make-fetch-happen: "npm:^14.0.3"
+    nopt: "npm:^8.0.0"
+    proc-log: "npm:^5.0.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^7.4.3"
+    which: "npm:^5.0.0"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 10c0/c38977ce502f1ea41ba2b8721bd5b49bc3d5b3f813eabfac8414082faf0620ccb5211e15c4daecc23ed9f5e3e9cc4da00e575a0bcfc2a95a069294f2afa1e0cd
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:latest":
   version: 11.0.0
   resolution: "node-gyp@npm:11.0.0"
   dependencies:
@@ -7776,6 +7805,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:~7.7.1":
+  version: 7.7.1
+  resolution: "semver@npm:7.7.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
+  languageName: node
+  linkType: hard
+
 "set-function-length@npm:^1.2.2":
   version: 1.2.2
   resolution: "set-function-length@npm:1.2.2"
@@ -8407,7 +8445,7 @@ __metadata:
   resolution: "terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector"
   dependencies:
     "@terascope/job-components": "npm:~1.9.3"
-    "@terascope/scripts": "npm:~1.10.0"
+    "@terascope/scripts": "npm:~1.10.1"
     "@types/convict": "npm:~6.1.6"
     convict: "npm:~6.2.4"
     node-rdkafka: "npm:~3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6636,26 +6636,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:latest":
-  version: 11.0.0
-  resolution: "node-gyp@npm:11.0.0"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    exponential-backoff: "npm:^3.1.1"
-    glob: "npm:^10.3.10"
-    graceful-fs: "npm:^4.2.6"
-    make-fetch-happen: "npm:^14.0.3"
-    nopt: "npm:^8.0.0"
-    proc-log: "npm:^5.0.0"
-    semver: "npm:^7.3.5"
-    tar: "npm:^7.4.3"
-    which: "npm:^5.0.0"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 10c0/a3b885bbee2d271f1def32ba2e30ffcf4562a3db33af06b8b365e053153e2dd2051b9945783c3c8e852d26a0f20f65b251c7e83361623383a99635c0280ee573
-  languageName: node
-  linkType: hard
-
 "node-int64@npm:^0.4.0":
   version: 0.4.0
   resolution: "node-int64@npm:0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6031,7 +6031,6 @@ __metadata:
     fs-extra: "npm:~11.3.0"
     jest: "npm:~29.7.0"
     jest-extended: "npm:~4.0.2"
-    node-gyp: "npm:11.1.0"
     semver: "npm:~7.7.1"
     terafoundation_kafka_connector: "npm:~1.2.1"
     teraslice-test-harness: "npm:~1.3.2"
@@ -6616,7 +6615,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:11.1.0":
+"node-gyp@npm:latest":
   version: 11.1.0
   resolution: "node-gyp@npm:11.1.0"
   dependencies:


### PR DESCRIPTION
This PR makes the following updates:
- terafoundation_kafka_connector
  - devDependencies:
    - @terascope/scripts from 1.10.0 to 1.10.1
- workspace:
  - devDependencies:
    - @terascope/scripts from 1.10.0 to 1.10.1
    - @types/node from 22.13.0 to 22.13.1
    - eslint from 9.19.0 to 9.20.0
    - semver from 7.7.0 to 7.7.1
 - remove node-gyp as a workspace dependency