### PR TITLE
[terafoundation_kafka_connector] Add `caCertificate` option to provide rootCA to kafka config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 > A bundle of [Kafka](https://kafka.apache.org/) operations and apis for [Teraslice](https://github.com/terascope/teraslice).
 
-
 - [Kafka Asset Bundle](#kafka-asset-bundle)
   - [Releases](#releases)
   - [Getting Started](#getting-started)
@@ -34,10 +33,10 @@ yarn global add teraslice-cli
 teraslice-cli asset deploy ...
 ```
 
-
 **IMPORTANT:** Additionally make sure have installed the required [connectors](#connectors).
 
 ## Connectors
+
 ### Kafka Connector
 
 > Terafoundation connector for Kafka producer and consumer clients.
@@ -56,21 +55,20 @@ The terafoundation level configuration is as follows:
 | --------- | -------- | ------ | ------ |
 | brokers | List of seed brokers for the kafka environment | String[] | optional, defaults to `["localhost:9092"]` |
 | security_protocol | Protocol used to communicate with brokers, may be set to `plaintext` or `ssl` | String | optional, defaults to `plaintext` |
-| ssl_ca_location | File or directory path to CA certificate(s) for verifying the broker's key | String | only used when `security_protocol` is set to `ssl` |
+| ssl_ca_location | File or directory path to CA certificate(s) for verifying the broker's key. Ignored if `ssl_ca_pem` is provided. | String | only used when `security_protocol` is set to `ssl` |
+| ssl_ca_pem | CA certificate string (PEM format) for verifying the broker's key. If provided `ssl_ca_location` will be ignored. | String | only used when `security_protocol` is set to `ssl` |
 | ssl_certificate_location | Path to client's public key (PEM) used for authentication | String | only used when `security_protocol` is set to `ssl` |
 | ssl_crl_location | Path to CRL for verifying broker's certificate validity | String | only used when `security_protocol` is set to `ssl` |
 | ssl_key_location | Path to client's private key (PEM) used for authentication | String | only used when `security_protocol` is set to `ssl` |
-| ssl_key_password | Private key passphrase | String | only used when `security_protocol` is set to `ssl` |                         |
+| ssl_key_password | Private key passphrase | String | only used when `security_protocol` is set to `ssl` |
 
 When using this connector in code, this connector exposes two different client implementations. One for producers `type: producer` and one for consumers `type: consumer`.
-
 
 | Configuration | Description | Type |  Notes |
 | --------- | -------- | ------ | ------ |
 | options | Consumer or Producer specific options | Object | required, see below |
 | topic_options | [librdkafka defined settings](https://github.com/edenhill/librdkafka/blob/v0.11.5/CONFIGURATION.md) that apply per topic | Object | optional, defaults to `{}` |
 | rdkafka_options | [librdkafka defined settings](https://github.com/edenhill/librdkafka/blob/v0.11.5/CONFIGURATION.md) that are not subscription specific | Object | optional, defaults to `{}` |
-
 
 The `options` object enables setting a few properties
 
@@ -79,7 +77,6 @@ The `options` object enables setting a few properties
 | type | What type of connector is required, either `consumer` or `producer`. | String | required, defaults to `consumer` |
 | group | For type 'consumer', what consumer group to use | String | optional |
 | poll_interval | For type 'producer', how often (in milliseconds) the producer connection is polled to keep it alive. | Number | optional, defaults to `100` |
-
 
 **Consumer connector configuration example:**
 
@@ -125,8 +122,25 @@ terafoundation:
                 brokers: "localhost:9092"
 ```
 
+With an encrypted connection to kafka broker:
 
-
+```yaml
+terafoundation:
+    connectors:
+        kafka:
+            default:
+                brokers: "localhost:9092"
+                security_protocol: "ssl"
+                ssl_ca_location: "app/certs/CAs/rootCA.pem"
+                ssl_ca_pem: |         # if provided ssl_ca_location will be ignored 
+                    -----BEGIN CERTIFICATE-----
+                    MIIFJzCCA4+gAwIBAgIQX6DM59eAmZLzzdoyD0jbtDANBgkqhkiG9w0BAQsFADCB
+                    ...
+                    ...
+                    ...
+                    R4eNRWMls7ceteGynZLUL0LULwW8Wio8w3Ht
+                    -----END CERTIFICATE-----
+```
 
 ## Development
 
@@ -150,7 +164,7 @@ yarn test
 
 Build a compiled asset bundle to deploy to a teraslice cluster.
 
-**Install Teraslice CLI**
+#### Install Teraslice CLI
 
 ```bash
 yarn global add teraslice-cli

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The terafoundation level configuration is as follows:
 | --------- | -------- | ------ | ------ |
 | brokers | List of seed brokers for the kafka environment | String[] | optional, defaults to `["localhost:9092"]` |
 | security_protocol | Protocol used to communicate with brokers, may be set to `plaintext` or `ssl` | String | optional, defaults to `plaintext` |
-| ssl_ca_location | File or directory path to CA certificate(s) for verifying the broker's key. Ignored if `ssl_ca_pem` is provided. | String | only used when `security_protocol` is set to `ssl` |
-| ssl_ca_pem | CA certificate string (PEM format) for verifying the broker's key. If provided `ssl_ca_location` will be ignored. | String | only used when `security_protocol` is set to `ssl` |
+| ssl_ca_location | File or directory path to CA certificate(s) for verifying the broker's key. Ignored if `caCertificate` is provided. | String | only used when `security_protocol` is set to `ssl` |
+| caCertificate | CA certificate string (PEM format) for verifying the broker's key. If provided `ssl_ca_location` will be ignored. | String | only used when `security_protocol` is set to `ssl` |
 | ssl_certificate_location | Path to client's public key (PEM) used for authentication | String | only used when `security_protocol` is set to `ssl` |
 | ssl_crl_location | Path to CRL for verifying broker's certificate validity | String | only used when `security_protocol` is set to `ssl` |
 | ssl_key_location | Path to client's private key (PEM) used for authentication | String | only used when `security_protocol` is set to `ssl` |
@@ -132,7 +132,7 @@ terafoundation:
                 brokers: "localhost:9092"
                 security_protocol: "ssl"
                 ssl_ca_location: "app/certs/CAs/rootCA.pem"
-                ssl_ca_pem: |         # if provided ssl_ca_location will be ignored 
+                caCertificate: |         # if provided then ssl_ca_location will be ignored 
                     -----BEGIN CERTIFICATE-----
                     MIIFJzCCA4+gAwIBAgIQX6DM59eAmZLzzdoyD0jbtDANBgkqhkiG9w0BAQsFADCB
                     ...

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.4.1",
+    "version": "5.5.0",
     "minimum_teraslice_version": "2.9.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.4.1",
+    "version": "5.5.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.4.1",
+    "version": "5.5.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "repository": "git@github.com:terascope/kafka-assets.git",
@@ -47,7 +47,7 @@
         "jest": "~29.7.0",
         "jest-extended": "~4.0.2",
         "semver": "~7.7.1",
-        "terafoundation_kafka_connector": "~1.2.1",
+        "terafoundation_kafka_connector": "~1.3.0",
         "teraslice-test-harness": "~1.3.2",
         "ts-jest": "~29.2.5",
         "typescript": "~5.7.3",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation_kafka_connector",
     "displayName": "Terafoundation Kafka Connector",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "homepage": "https://github.com/terascope/kafka-assets",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/packages/terafoundation_kafka_connector/src/index.ts
+++ b/packages/terafoundation_kafka_connector/src/index.ts
@@ -207,6 +207,7 @@ class KafkaConnector {
             'security.protocol': config.security_protocol,
             'ssl.crl.location': config.ssl_crl_location,
             'ssl.ca.location': config.ssl_ca_location,
+            'ssl.ca.pem': config.ssl_ca_pem,
             'ssl.certificate.location': config.ssl_certificate_location,
             'ssl.key.location': config.ssl_key_location,
             'ssl.key.password': config.ssl_key_password,

--- a/packages/terafoundation_kafka_connector/src/index.ts
+++ b/packages/terafoundation_kafka_connector/src/index.ts
@@ -207,7 +207,7 @@ class KafkaConnector {
             'security.protocol': config.security_protocol,
             'ssl.crl.location': config.ssl_crl_location,
             'ssl.ca.location': config.ssl_ca_location,
-            'ssl.ca.pem': config.ssl_ca_pem,
+            'ssl.ca.pem': config.caCertificate,
             'ssl.certificate.location': config.ssl_certificate_location,
             'ssl.key.location': config.ssl_key_location,
             'ssl.key.password': config.ssl_key_password,

--- a/packages/terafoundation_kafka_connector/src/interfaces.ts
+++ b/packages/terafoundation_kafka_connector/src/interfaces.ts
@@ -9,10 +9,10 @@ export interface KafkaConnectorConfig {
     security_protocol?: 'plaintext' | 'ssl';
 
     // SSL configuration
-    ssl_crl_location?: string;
+    caCertificate?: string;
     ssl_ca_location?: string;
-    ssl_ca_pem?: string;
     ssl_certificate_location?: string;
+    ssl_crl_location?: string;
     ssl_key_location?: string;
     ssl_key_password?: string;
 }

--- a/packages/terafoundation_kafka_connector/src/interfaces.ts
+++ b/packages/terafoundation_kafka_connector/src/interfaces.ts
@@ -11,6 +11,7 @@ export interface KafkaConnectorConfig {
     // SSL configuration
     ssl_crl_location?: string;
     ssl_ca_location?: string;
+    ssl_ca_pem?: string;
     ssl_certificate_location?: string;
     ssl_key_location?: string;
     ssl_key_password?: string;

--- a/packages/terafoundation_kafka_connector/src/schema.ts
+++ b/packages/terafoundation_kafka_connector/src/schema.ts
@@ -15,7 +15,12 @@ export default {
         format: 'optional_String'
     },
     ssl_ca_location: {
-        doc: 'File or directory path to CA certificate(s) for verifying the broker\'s key',
+        doc: 'File or directory path to CA certificate(s) for verifying the broker\'s key. Ignored if `ssl_ca_pem` is provided.',
+        default: undefined,
+        format: 'optional_String'
+    },
+    ssl_ca_pem: {
+        doc: 'CA certificate string (PEM format) for verifying the broker\'s key. If provided `ssl_ca_location` will be ignored.',
         default: undefined,
         format: 'optional_String'
     },

--- a/packages/terafoundation_kafka_connector/src/schema.ts
+++ b/packages/terafoundation_kafka_connector/src/schema.ts
@@ -15,11 +15,11 @@ export default {
         format: 'optional_String'
     },
     ssl_ca_location: {
-        doc: 'File or directory path to CA certificate(s) for verifying the broker\'s key. Ignored if `ssl_ca_pem` is provided.',
+        doc: 'File or directory path to CA certificate(s) for verifying the broker\'s key. Ignored if `caCertificate` is provided.',
         default: undefined,
         format: 'optional_String'
     },
-    ssl_ca_pem: {
+    caCertificate: {
         doc: 'CA certificate string (PEM format) for verifying the broker\'s key. If provided `ssl_ca_location` will be ignored.',
         default: undefined,
         format: 'optional_String'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6032,7 +6032,7 @@ __metadata:
     jest: "npm:~29.7.0"
     jest-extended: "npm:~4.0.2"
     semver: "npm:~7.7.1"
-    terafoundation_kafka_connector: "npm:~1.2.1"
+    terafoundation_kafka_connector: "npm:~1.3.0"
     teraslice-test-harness: "npm:~1.3.2"
     ts-jest: "npm:~29.2.5"
     typescript: "npm:~5.7.3"
@@ -8419,7 +8419,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation_kafka_connector@npm:~1.2.1, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
+"terafoundation_kafka_connector@npm:~1.3.0, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
   version: 0.0.0-use.local
   resolution: "terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector"
   dependencies:


### PR DESCRIPTION
This PR makes the following changes:
- Add `caCertificate` to the `kafkaConfig` options, allowing a CA cert string to be passed in through `terafoundation`
  - NOTE: `node-rdkafka` will ignore `ssl_ca_location` if `caCertificate` is set
- bump terafoundation_kafka_connector from 1.2.1 to 1.3.0
- bump kafka-assets from 5.4.1 to 5.5.0