### PR TITLE
Update node rdkafka to 3.3.1

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.5.0",
+    "version": "5.6.0",
     "minimum_teraslice_version": "2.9.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.5.0",
+    "version": "5.6.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.5.0",
+    "version": "5.6.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "repository": "git@github.com:terascope/kafka-assets.git",
@@ -47,7 +47,7 @@
         "jest": "~29.7.0",
         "jest-extended": "~4.0.2",
         "semver": "~7.7.1",
-        "terafoundation_kafka_connector": "~1.3.0",
+        "terafoundation_kafka_connector": "~1.4.0",
         "teraslice-test-harness": "~1.3.2",
         "ts-jest": "~29.2.6",
         "typescript": "~5.7.3",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation_kafka_connector",
     "displayName": "Terafoundation Kafka Connector",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "homepage": "https://github.com/terascope/kafka-assets",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -22,7 +22,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "node-rdkafka": "~3.2.1"
+        "node-rdkafka": "~3.3.1"
     },
     "devDependencies": {
         "@terascope/job-components": "~1.9.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6637,12 +6637,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.14.0, nan@npm:^2.19.0":
+"nan@npm:^2.14.0":
   version: 2.22.0
   resolution: "nan@npm:2.22.0"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/d5d31aefdb218deba308d44867c5f432b4d3aabeb57c70a2b236d62652e9fee7044e5d5afd380d9fef022fe7ebb2f2d6c85ca3cbcac5031aaca3592c844526bb
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.22.0":
+  version: 2.22.2
+  resolution: "nan@npm:2.22.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/971f963b8120631880fa47a389c71b00cadc1c1b00ef8f147782a3f4387d4fc8195d0695911272d57438c11562fb27b24c4ae5f8c05d5e4eeb4478ba51bb73c5
   languageName: node
   linkType: hard
 
@@ -6710,14 +6719,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-rdkafka@npm:~3.2.1":
-  version: 3.2.1
-  resolution: "node-rdkafka@npm:3.2.1"
+"node-rdkafka@npm:~3.3.1":
+  version: 3.3.1
+  resolution: "node-rdkafka@npm:3.3.1"
   dependencies:
     bindings: "npm:^1.3.1"
-    nan: "npm:^2.19.0"
+    nan: "npm:^2.22.0"
     node-gyp: "npm:latest"
-  checksum: 10c0/84d202bf82c48454cca8073c83afaaad66edbc3a75a5bc160544078550647d5ea7460dff7426ac36e63497f21b0b641471a54c64653313d1d74519fb8eddbea6
+  checksum: 10c0/6a7bfa42d9821216a20808a4d6bb99aa22a3128f0061cbfdc22ba61c3581a04ec1875564db1053118eff35425b30773fc92a1c1ae24cd0125c5d7fd0593f1e33
   languageName: node
   linkType: hard
 
@@ -8486,7 +8495,7 @@ __metadata:
     "@terascope/scripts": "npm:~1.10.4"
     "@types/convict": "npm:~6.1.6"
     convict: "npm:~6.2.4"
-    node-rdkafka: "npm:~3.2.1"
+    node-rdkafka: "npm:~3.3.1"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6100,7 +6100,7 @@ __metadata:
     jest: "npm:~29.7.0"
     jest-extended: "npm:~4.0.2"
     semver: "npm:~7.7.1"
-    terafoundation_kafka_connector: "npm:~1.3.0"
+    terafoundation_kafka_connector: "npm:~1.4.0"
     teraslice-test-harness: "npm:~1.3.2"
     ts-jest: "npm:~29.2.6"
     typescript: "npm:~5.7.3"
@@ -8487,7 +8487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation_kafka_connector@npm:~1.3.0, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
+"terafoundation_kafka_connector@npm:~1.4.0, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
   version: 0.0.0-use.local
   resolution: "terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector"
   dependencies:


### PR DESCRIPTION
This PR makes the following changes:
- update `node-rdkafka` from 3.2.1 to 3.3.1
- bump `terafoundation_kafka_connector` from 1.3.0 to 1.4.0
- bump `kafka-asset` from 5.5.0 to 5.6.0

`node-rdkafka` now uses `librdkafka` 2.8.0