### PR TITLE
bundled dependency updates for 3-31-2025

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "devDependencies": {
         "@terascope/eslint-config": "~1.1.10",
         "@terascope/job-components": "~1.9.8",
-        "@terascope/scripts": "~1.13.0",
+        "@terascope/scripts": "~1.14.0",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~29.5.14",
-        "@types/node": "~22.13.13",
-        "@types/semver": "~7.5.8",
+        "@types/node": "~22.13.14",
+        "@types/semver": "~7.7.0",
         "@types/uuid": "~10.0.0",
         "bunyan": "~1.8.15",
         "eslint": "~9.23.0",
@@ -48,7 +48,7 @@
         "jest-extended": "~4.0.2",
         "semver": "~7.7.1",
         "terafoundation_kafka_connector": "~1.4.0",
-        "teraslice-test-harness": "~1.3.3",
+        "teraslice-test-harness": "~1.3.4",
         "ts-jest": "~29.3.0",
         "typescript": "~5.8.2",
         "uuid": "~11.1.0"

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -26,7 +26,7 @@
     },
     "devDependencies": {
         "@terascope/job-components": "~1.9.8",
-        "@terascope/scripts": "~1.13.0",
+        "@terascope/scripts": "~1.14.0",
         "@types/convict": "~6.1.6",
         "convict": "~6.2.4"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1191,9 +1191,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.13.0":
-  version: 1.13.0
-  resolution: "@terascope/scripts@npm:1.13.0"
+"@terascope/scripts@npm:~1.14.0":
+  version: 1.14.0
+  resolution: "@terascope/scripts@npm:1.14.0"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
     "@terascope/utils": "npm:~1.7.7"
@@ -1224,7 +1224,7 @@ __metadata:
       optional: true
   bin:
     ts-scripts: ./bin/ts-scripts.js
-  checksum: 10c0/79b9534d813b390348504f9667f2baec3945be128be5ea3a8856825e9c222d353deef8c3e11cbafa476b136bd90af87f6e53fadaaad603f65994c80b6301739c
+  checksum: 10c0/0313c8334b34d74894c9f8e2a4f63dfb9381f0887839ff5ccfdcd2104a744ff2c0a215f5417892f67bb45d86b46248fc9b4c97f3443af50919395f17b02a7ce8
   languageName: node
   linkType: hard
 
@@ -1706,19 +1706,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~22.13.13":
-  version: 22.13.13
-  resolution: "@types/node@npm:22.13.13"
+"@types/node@npm:~22.13.14":
+  version: 22.13.14
+  resolution: "@types/node@npm:22.13.14"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10c0/daf792ba5dcff1316abf4b33680f94b792f8d54d6ae495efc8929531e0ba1284a248d29aab117d2259f9280284d986ad5799b193b0516e2b926d713aab835f7d
+  checksum: 10c0/fa2ab5b8277bfbcc86c42e46a3ea9871b0d559894cc9d955685d17178c9499f0b1bf03d1d1ea8d92ef2dda818988f4035acb8abf9dc15423a998fa56173ab804
   languageName: node
   linkType: hard
 
-"@types/semver@npm:~7.5.8":
-  version: 7.5.8
-  resolution: "@types/semver@npm:7.5.8"
-  checksum: 10c0/8663ff927234d1c5fcc04b33062cb2b9fcfbe0f5f351ed26c4d1e1581657deebd506b41ff7fdf89e787e3d33ce05854bc01686379b89e9c49b564c4cfa988efa
+"@types/semver@npm:~7.7.0":
+  version: 7.7.0
+  resolution: "@types/semver@npm:7.7.0"
+  checksum: 10c0/6b5f65f647474338abbd6ee91a6bbab434662ddb8fe39464edcbcfc96484d388baad9eb506dff217b6fc1727a88894930eb1f308617161ac0f376fe06be4e1ee
   languageName: node
   linkType: hard
 
@@ -6091,11 +6091,11 @@ __metadata:
   dependencies:
     "@terascope/eslint-config": "npm:~1.1.10"
     "@terascope/job-components": "npm:~1.9.8"
-    "@terascope/scripts": "npm:~1.13.0"
+    "@terascope/scripts": "npm:~1.14.0"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~29.5.14"
-    "@types/node": "npm:~22.13.13"
-    "@types/semver": "npm:~7.5.8"
+    "@types/node": "npm:~22.13.14"
+    "@types/semver": "npm:~7.7.0"
     "@types/uuid": "npm:~10.0.0"
     bunyan: "npm:~1.8.15"
     eslint: "npm:~9.23.0"
@@ -6104,7 +6104,7 @@ __metadata:
     jest-extended: "npm:~4.0.2"
     semver: "npm:~7.7.1"
     terafoundation_kafka_connector: "npm:~1.4.0"
-    teraslice-test-harness: "npm:~1.3.3"
+    teraslice-test-harness: "npm:~1.3.4"
     ts-jest: "npm:~29.3.0"
     typescript: "npm:~5.8.2"
     uuid: "npm:~11.1.0"
@@ -8495,23 +8495,23 @@ __metadata:
   resolution: "terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector"
   dependencies:
     "@terascope/job-components": "npm:~1.9.8"
-    "@terascope/scripts": "npm:~1.13.0"
+    "@terascope/scripts": "npm:~1.14.0"
     "@types/convict": "npm:~6.1.6"
     convict: "npm:~6.2.4"
     node-rdkafka: "npm:~3.3.1"
   languageName: unknown
   linkType: soft
 
-"teraslice-test-harness@npm:~1.3.3":
-  version: 1.3.3
-  resolution: "teraslice-test-harness@npm:1.3.3"
+"teraslice-test-harness@npm:~1.3.4":
+  version: 1.3.4
+  resolution: "teraslice-test-harness@npm:1.3.4"
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.1.0"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.0"
   peerDependencies:
     "@terascope/job-components": ">=1.9.8"
-  checksum: 10c0/be70df34401a3cb2d94d84686f960028673bfa66de491de5c4ed22549539da61e5027567231a4187436df851fe9e5eee9e4850f06a8244022d8110257c2c580f
+  checksum: 10c0/85eaed8c37c2555d98d9571026e72ffc0f2a03c040d95d672e30ed57ee16384c1de85c3f78e5cfe73c550f48e7f40583bf45a5acf0730c10b51147f9e0e5d470
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the following packages:
# kafka-asset-bundle
  - devDependencies
    - @terascope/scripts from 1.13.0 to 1.14.0
    - @types/node from 22.13.13 to 22.13.14
    - @types/semver from 7.5.8 to 7.7.0
    - teraslice-test-harness from 1.3.3 to 1.3.4
# terafoundation_kafka_connector
  - devDependencies
    - @terascope/scripts from 1.13.0 to 1.14.0