### PR TITLE
Bump asset to publish docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,4 @@ updates:
       - godber
       - sotojn
       - busma13
+      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,16 @@ updates:
       - dependency-name: '@types/node'
         versions:
           - '>= 17.0.0'
+  - package-ecosystem: npm
+    directory: '/website'
+    schedule:
+      interval: monthly
+      time: '04:00'
+      timezone: US/Arizona
+    ignore:
+      - dependency-name: "*"
+    open-pull-requests-limit: 3
+    assignees:
+      - godber
+      - sotojn
+      - busma13

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.6.0",
+    "version": "5.6.1",
     "minimum_teraslice_version": "2.9.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.6.0",
+    "version": "5.6.1",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.6.0",
+    "version": "5.6.1",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",
-    "repository": "git@github.com:terascope/kafka-assets.git",
-    "documentation": "https://terascope.github.io/kafka-assets",
     "bugs": {
         "url": "https://github.com/terascope/kafka-assets/issues"
     },
+    "repository": "git@github.com:terascope/kafka-assets.git",
     "license": "MIT",
     "author": "Terascope, LLC <info@terascope.io>",
     "type": "module",
@@ -64,6 +63,7 @@
         "node": ">=18.0.0",
         "yarn": ">=1.22.22"
     },
+    "documentation": "https://terascope.github.io/kafka-assets",
     "terascope": {
         "root": true,
         "testSuite": "stream",


### PR DESCRIPTION
This PR makes the following changes:
- bump asset version from 5.6.0 to 5.6.1
- set dependabot to ignore ./website dependency updates