### PR TITLE
[website] fix algolia doc index

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -147,7 +147,7 @@ module.exports = {
         algolia: {
             appId: 'KD1DQTOI4M',
             apiKey: '39a27eca4d31c921b2b412344351996e',
-            indexName: 'terascope_kafka-assets'
+            indexName: 'terascope_teraslice_kafka-assets'
         },
         mermaid: {
             theme: {


### PR DESCRIPTION
Algolia requires a certain format for its indices, so it needed to be updated in the docusaurus config.