### PR TITLE
[website] turn off Algolia contextual search

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.6.1",
+    "version": "5.6.2",
     "minimum_teraslice_version": "2.9.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.6.1",
+    "version": "5.6.2",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.6.1",
+    "version": "5.6.2",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -147,7 +147,8 @@ module.exports = {
         algolia: {
             appId: 'KD1DQTOI4M',
             apiKey: '39a27eca4d31c921b2b412344351996e',
-            indexName: 'terascope_teraslice_kafka-assets'
+            indexName: 'terascope_teraslice_kafka-assets',
+            contextualSearch: false
         },
         mermaid: {
             theme: {


### PR DESCRIPTION
This PR makes the following changes:
- set algolia `contextualSearch` to false on the docs website
- bump asset version from v5.6.1 to v5.6.2 to make a release that builds the docs