### PR TITLE
Fix broken doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 
 You can find a list of releases, changes, and pre-built asset bundles [here](https://github.com/terascope/kafka-assets/releases).
 
+## Documentation
+
+[https://terascope.github.io/kafka-assets/](https://terascope.github.io/kafka-assets/)
+
 ## Getting Started
 
 This asset bundle requires a running Teraslice cluster, you can find the documentation [here](https://terascope.github.io/teraslice/docs/overview/).

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.8.0",
+    "version": "5.8.1",
     "minimum_teraslice_version": "2.9.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.8.0",
+    "version": "5.8.1",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/docs/asset/apis/kafka_dead_letter.md
+++ b/docs/asset/apis/kafka_dead_letter.md
@@ -4,7 +4,7 @@ This is a Teraslice [api](https://terascope.github.io/teraslice/docs/jobs/types-
 
 Any record that fails using the `tryRecord` operation api, or any record directly used by the `rejectRecord` operation api will be collected and sent to a kafka topic at the end of a slice.
 
-More specifically it is sent at the `onSliceFinalizing` [operation lifecycle event](https://terascope.github.io/teraslice/docs/packages/job-components/api/interfaces/workeroperationlifecycle).
+More specifically it is sent at the `onSliceFinalizing` [operation lifecycle event](https://terascope.github.io/teraslice/docs/packages/job-components/api/interfaces/operation-lifecycle/interfaces/WorkerOperationLifeCycle).
 
 It is useful to keep a kafka topic of all failed entities to inspect or  reprocess them later on or you could have a job run in parallel processing the queue of failed records.
 

--- a/docs/asset/apis/kafka_reader_api.md
+++ b/docs/asset/apis/kafka_reader_api.md
@@ -2,7 +2,7 @@
 
 This is a [teraslice api](https://terascope.github.io/teraslice/docs/jobs/configuration#apis), which provides an API to read messages from a Kafka topic and can be utilized by any processor, reader or slicer.
 
-The `kafka_reader_api` will provide an [api factory](https://terascope.github.io/teraslice/docs/packages/job-components/api/classes/apifactory), which is a singleton that can create, cache and manage multiple kafka readers that can be accessed in any operation through the `getAPI` method on the operation.
+The `kafka_reader_api` will provide an [api factory](https://terascope.github.io/teraslice/docs/packages/job-components/api/operations/api-factory/overview), which is a singleton that can create, cache and manage multiple kafka readers that can be accessed in any operation through the `getAPI` method on the operation.
 
 This is a high throughput operation. This reader handles all the complexity of balancing writes across partitions and managing ever-changing brokers.
 

--- a/docs/asset/apis/kafka_sender_api.md
+++ b/docs/asset/apis/kafka_sender_api.md
@@ -2,7 +2,7 @@
 
 The kafka_sender_api is a [teraslice api](https://terascope.github.io/teraslice/docs/jobs/configuration#apis), which provides the functionality to send messages to a kafka topic and can be utilized by any processor, reader or slicer.  It is a high throughput operation that uses [node-rdkafka](https://github.com/Blizzard/node-rdkafka) underneath the hood and is the core of the [kafka_sender](../operations/kafka_sender.md).  It contains the same behavior, functionality, and configuration properties of the kafka_sender.
 
- The `kafka_sender_api` provides an [api factory](https://terascope.github.io/teraslice/docs/packages/job-components/api/classes/apifactory), which is a [singleton](https://en.wikipedia.org/wiki/Singleton_pattern) that can create, cache and manage multiple kafka senders.  These api functions can then be accessed in any operation through the `getAPI` method.
+ The `kafka_sender_api` provides an [api factory](https://terascope.github.io/teraslice/docs/packages/job-components/api/operations/api-factory/overview), which is a [singleton](https://en.wikipedia.org/wiki/Singleton_pattern) that can create, cache and manage multiple kafka senders.  These api functions can then be accessed in any operation through the `getAPI` method.
 
 ## Usage
 
@@ -166,7 +166,7 @@ apiManager.get('normalClient') === undefined
 
 ## Kafka Sender Instance
 
-The [sender api](https://terascope.github.io/teraslice/docs/packages/job-components/api/interfaces/routesenderapi) returned from the APIFactory's create method.
+The [sender api](https://terascope.github.io/teraslice/docs/packages/utils/api/interfaces/interfaces/RouteSenderAPI/) returned from the APIFactory's create method.
 
 ### send (async)
 

--- a/docs/packages/terafoundation_kafka_connector/overview.md
+++ b/docs/packages/terafoundation_kafka_connector/overview.md
@@ -3,6 +3,6 @@ title: terafoundation_kafka_connector
 sidebar_label: terafoundation_kafka_connector
 ---
 
-The Terafoundation Kafka Connector facilitates a connection between a [terafoundation](https://terascope.github.io/teraslice/docs/packages/terafoundation/overview) based project and one or more [kafka](kafka.apache.org) instances.
+The Terafoundation Kafka Connector facilitates a connection between a [terafoundation](https://terascope.github.io/teraslice/docs/packages/terafoundation/overview) based project and one or more [kafka](https://kafka.apache.org) instances.
 
 See the [overview](/) for installation and configuration details.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.8.0",
+    "version": "5.8.1",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",


### PR DESCRIPTION
This PR makes the following changes:
- fixes broken links in the docs
- bump: (patch) kafka-assets@5.8.1, kafka-asset-bundle@5.8.1 (this will create a release and build new docs)