### PR TITLE
Update node rdkafka from v3.4.0 to v3.4.1

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.8.1",
+    "version": "5.8.2",
     "minimum_teraslice_version": "2.9.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.8.1",
+    "version": "5.8.2",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.8.1",
+    "version": "5.8.2",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",
@@ -52,7 +52,7 @@
         "jest": "~30.0.0",
         "jest-extended": "~6.0.0",
         "semver": "~7.7.2",
-        "terafoundation_kafka_connector": "~1.5.0",
+        "terafoundation_kafka_connector": "~1.5.1",
         "teraslice-test-harness": "~1.3.5",
         "ts-jest": "~29.4.0",
         "typescript": "~5.8.3",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation_kafka_connector",
     "displayName": "Terafoundation Kafka Connector",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "homepage": "https://github.com/terascope/kafka-assets",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -22,7 +22,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "node-rdkafka": "~3.4.0"
+        "node-rdkafka": "~3.4.1"
     },
     "devDependencies": {
         "@terascope/job-components": "~1.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6623,7 +6623,7 @@ __metadata:
     jest: "npm:~30.0.0"
     jest-extended: "npm:~6.0.0"
     semver: "npm:~7.7.2"
-    terafoundation_kafka_connector: "npm:~1.5.0"
+    terafoundation_kafka_connector: "npm:~1.5.1"
     teraslice-test-harness: "npm:~1.3.5"
     ts-jest: "npm:~29.4.0"
     typescript: "npm:~5.8.3"
@@ -8960,7 +8960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation_kafka_connector@npm:~1.5.0, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
+"terafoundation_kafka_connector@npm:~1.5.1, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
   version: 0.0.0-use.local
   resolution: "terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7244,14 +7244,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-rdkafka@npm:~3.4.0":
-  version: 3.4.0
-  resolution: "node-rdkafka@npm:3.4.0"
+"node-rdkafka@npm:~3.4.1":
+  version: 3.4.1
+  resolution: "node-rdkafka@npm:3.4.1"
   dependencies:
     bindings: "npm:^1.3.1"
     nan: "npm:^2.22.0"
     node-gyp: "npm:latest"
-  checksum: 10c0/7f74ec82df655c58903af07eb210cfcf444350b2ed4f58e1f4ab8ead9f2f64bbbfc1e0060fbc49604b4020e63c021b68d98facce911af9005a53838c3c3b0073
+  checksum: 10c0/414ecd9887a469fefc1cf553f5df3629726a83e6371ee85a2b6c0dc020203e6797355f3557d28ed20b8fa20900de822e9268bc08678afd2b03629d988685950d
   languageName: node
   linkType: hard
 
@@ -8968,7 +8968,7 @@ __metadata:
     "@terascope/scripts": "npm:~1.18.0"
     "@types/convict": "npm:~6.1.6"
     convict: "npm:~6.2.4"
-    node-rdkafka: "npm:~3.4.0"
+    node-rdkafka: "npm:~3.4.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR makes the following changes:
- update node rdkafka from v3.4.0 to v3.4.1
  - this updates librdkafka from v2.10.0 to v2.10.1
- bump: (patch) terafoundation_kafka_connector@1.5.1
- bump: (patch) kafka-assets@5.8.2
- bump: (patch) kafka-asset-bundle@5.8.2