### PR TITLE
bundled dependency updates for 8-18-2025

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -22,7 +22,7 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@terascope/job-components": "~1.12.1",
+        "@terascope/job-components": "~1.12.2",
         "@terascope/types": "~1.4.4"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
-        "@terascope/eslint-config": "~1.1.22",
-        "@terascope/job-components": "~1.12.1",
-        "@terascope/scripts": "~1.21.1",
+        "@terascope/eslint-config": "~1.1.23",
+        "@terascope/job-components": "~1.12.2",
+        "@terascope/scripts": "~1.21.3",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
-        "@types/node": "~24.2.1",
+        "@types/node": "~24.3.0",
         "@types/semver": "~7.7.0",
         "@types/uuid": "~10.0.0",
         "bunyan": "~1.8.15",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -25,8 +25,8 @@
         "node-rdkafka": "~3.4.1"
     },
     "devDependencies": {
-        "@terascope/job-components": "~1.12.1",
-        "@terascope/scripts": "~1.21.1",
+        "@terascope/job-components": "~1.12.2",
+        "@terascope/scripts": "~1.21.3",
         "@types/convict": "~6.1.6",
         "convict": "~6.2.4"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,15 +632,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:~1.3.1":
-  version: 1.3.1
-  resolution: "@eslint/compat@npm:1.3.1"
+"@eslint/compat@npm:~1.3.2":
+  version: 1.3.2
+  resolution: "@eslint/compat@npm:1.3.2"
   peerDependencies:
     eslint: ^8.40 || 9
   peerDependenciesMeta:
     eslint:
       optional: true
-  checksum: 10c0/8dfcea5ecb854111f9c0acc23a469e0a25cdaddceb5fb40c47988c247d6e32ec199bcd00f1b8ba9ed779228526552703c4b74948169e78b78b5fd814e04b042b
+  checksum: 10c0/9b95b49ee74c50adf8f0e45066b471bc76842c43d4721727ff93d186745bdd1679d18420c992a05eab3bb41762672cd3faa5c56c99325dbb97200f7533cbd2bf
   languageName: node
   linkType: hard
 
@@ -655,26 +655,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@eslint/config-helpers@npm:0.3.0"
-  checksum: 10c0/013ae7b189eeae8b30cc2ee87bc5c9c091a9cd615579003290eb28bebad5d78806a478e74ba10b3fe08ed66975b52af7d2cd4b4b43990376412b14e5664878c8
-  languageName: node
-  linkType: hard
-
 "@eslint/config-helpers@npm:^0.3.1":
   version: 0.3.1
   resolution: "@eslint/config-helpers@npm:0.3.1"
   checksum: 10c0/f6c5b3a0b76a0d7d84cc93e310c259e6c3e0792ddd0a62c5fc0027796ffae44183432cb74b2c2b1162801ee1b1b34a6beb5d90a151632b4df7349f994146a856
-  languageName: node
-  linkType: hard
-
-"@eslint/core@npm:^0.15.0, @eslint/core@npm:^0.15.1":
-  version: 0.15.1
-  resolution: "@eslint/core@npm:0.15.1"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/abaf641940776638b8c15a38d99ce0dac551a8939310ec81b9acd15836a574cf362588eaab03ab11919bc2a0f9648b19ea8dee33bf12675eb5b6fd38bda6f25e
   languageName: node
   linkType: hard
 
@@ -704,14 +688,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.32.0, @eslint/js@npm:~9.32.0":
-  version: 9.32.0
-  resolution: "@eslint/js@npm:9.32.0"
-  checksum: 10c0/f71e8f9146638d11fb15238279feff98801120a4d4130f1c587c4f09b024ff5ec01af1ba88e97ba6b7013488868898a668f77091300cc3d4394c7a8ed32d2667
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.33.0":
+"@eslint/js@npm:9.33.0, @eslint/js@npm:~9.33.0":
   version: 9.33.0
   resolution: "@eslint/js@npm:9.33.0"
   checksum: 10c0/4c42c9abde76a183b8e47205fd6c3116b058f82f07b6ad4de40de56cdb30a36e9ecd40efbea1b63a84d08c206aadbb0aa39a890197e1ad6455a8e542df98f186
@@ -722,16 +699,6 @@ __metadata:
   version: 2.1.6
   resolution: "@eslint/object-schema@npm:2.1.6"
   checksum: 10c0/b8cdb7edea5bc5f6a96173f8d768d3554a628327af536da2fc6967a93b040f2557114d98dbcdbf389d5a7b290985ad6a9ce5babc547f36fc1fde42e674d11a56
-  languageName: node
-  linkType: hard
-
-"@eslint/plugin-kit@npm:^0.3.4":
-  version: 0.3.4
-  resolution: "@eslint/plugin-kit@npm:0.3.4"
-  dependencies:
-    "@eslint/core": "npm:^0.15.1"
-    levn: "npm:^0.4.1"
-  checksum: 10c0/64331ca100f62a0115d10419a28059d0f377e390192163b867b9019517433d5073d10b4ec21f754fa01faf832aceb34178745924baab2957486f8bf95fd628d2
   languageName: node
   linkType: hard
 
@@ -1482,7 +1449,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin@npm:~5.2.2":
+"@stylistic/eslint-plugin@npm:~5.2.3":
   version: 5.2.3
   resolution: "@stylistic/eslint-plugin@npm:5.2.3"
   dependencies:
@@ -1507,27 +1474,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/eslint-config@npm:~1.1.22":
-  version: 1.1.22
-  resolution: "@terascope/eslint-config@npm:1.1.22"
+"@terascope/eslint-config@npm:~1.1.23":
+  version: 1.1.23
+  resolution: "@terascope/eslint-config@npm:1.1.23"
   dependencies:
-    "@eslint/compat": "npm:~1.3.1"
-    "@eslint/js": "npm:~9.32.0"
-    "@stylistic/eslint-plugin": "npm:~5.2.2"
+    "@eslint/compat": "npm:~1.3.2"
+    "@eslint/js": "npm:~9.33.0"
+    "@stylistic/eslint-plugin": "npm:~5.2.3"
     "@typescript-eslint/eslint-plugin": "npm:~8.39.0"
     "@typescript-eslint/parser": "npm:~8.39.0"
-    eslint: "npm:~9.32.0"
+    eslint: "npm:~9.33.0"
     eslint-plugin-import: "npm:~2.32.0"
     eslint-plugin-jest: "npm:~29.0.1"
     eslint-plugin-jest-dom: "npm:~5.5.0"
     eslint-plugin-jsx-a11y: "npm:~6.10.2"
     eslint-plugin-react: "npm:~7.37.5"
     eslint-plugin-react-hooks: "npm:~5.2.0"
-    eslint-plugin-testing-library: "npm:~7.6.3"
+    eslint-plugin-testing-library: "npm:~7.6.4"
     globals: "npm:~16.3.0"
     typescript: "npm:~5.9.2"
     typescript-eslint: "npm:~8.39.0"
-  checksum: 10c0/9a134f9ee3a3390b820d4a7334e77f980012ddd21d17d0e3600df6b3540f112caeb97f3cb62c632844729cc1a668e52fa5ded0085aeb48d94bdc18092b296f2d
+  checksum: 10c0/4db177f0feedcd373b03ee0d46a264b5591eeed9abcb4a7a6fad1a7bff3334a5fb2e1a4f68e8e8025f6a9c263b1190aa67bb79eea20cec323c17ac0f3a00b87a
   languageName: node
   linkType: hard
 
@@ -1546,12 +1513,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.12.1":
-  version: 1.12.1
-  resolution: "@terascope/job-components@npm:1.12.1"
+"@terascope/job-components@npm:~1.12.2":
+  version: 1.12.2
+  resolution: "@terascope/job-components@npm:1.12.2"
   dependencies:
     "@terascope/types": "npm:~1.4.4"
-    "@terascope/utils": "npm:~1.10.1"
+    "@terascope/utils": "npm:~1.10.2"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
@@ -1560,16 +1527,16 @@ __metadata:
     prom-client: "npm:~15.1.3"
     semver: "npm:~7.7.2"
     uuid: "npm:~11.1.0"
-  checksum: 10c0/1f88b79d787e157fd068992721a32cea916399dd7e5e9925e1387dd91c585af923adaa1958ce2e0408a34a3f48d13296cc260bb7c5c755264e32608bfe5cff90
+  checksum: 10c0/e79513ec70b9ee5564ea1b12cb9cae1f58323e8e1d923e61843d6e42b4418f89e0c2d10624e5029ec11cbab51f1cedd699fab74f146518d7271ab06125b28998
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.21.1":
-  version: 1.21.1
-  resolution: "@terascope/scripts@npm:1.21.1"
+"@terascope/scripts@npm:~1.21.3":
+  version: 1.21.3
+  resolution: "@terascope/scripts@npm:1.21.3"
   dependencies:
     "@kubernetes/client-node": "npm:~1.3.0"
-    "@terascope/utils": "npm:~1.10.1"
+    "@terascope/utils": "npm:~1.10.2"
     execa: "npm:~9.6.0"
     fs-extra: "npm:~11.3.1"
     globby: "npm:~14.1.0"
@@ -1586,7 +1553,7 @@ __metadata:
     signale: "npm:~1.4.0"
     sort-package-json: "npm:~3.4.0"
     toposort: "npm:~2.0.2"
-    typedoc: "npm:~0.28.9"
+    typedoc: "npm:~0.28.10"
     typedoc-plugin-markdown: "npm:~4.8.0"
     yaml: "npm:^2.8.1"
     yargs: "npm:~18.0.0"
@@ -1597,7 +1564,7 @@ __metadata:
       optional: true
   bin:
     ts-scripts: ./bin/ts-scripts.js
-  checksum: 10c0/757077b846b0f332734ae274d23914a8ad380976d977c58e93818dc81d5fd133abb3fbee27af08c9aed3eddf0ac1a329f0179ffa87c7f5f746d3f37d826e468a
+  checksum: 10c0/24428d807691a10b0bc0cfe371b5674c1bbea1b950a326bd744bf73c562e3ae2f9c47bc5fba8e394d13630b206f2d2a3046deeeba9e0ecfa2a7bfa793d5019f7
   languageName: node
   linkType: hard
 
@@ -1610,9 +1577,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/utils@npm:~1.10.1":
-  version: 1.10.1
-  resolution: "@terascope/utils@npm:1.10.1"
+"@terascope/utils@npm:~1.10.2":
+  version: 1.10.2
+  resolution: "@terascope/utils@npm:1.10.2"
   dependencies:
     "@chainsafe/is-ip": "npm:~2.1.0"
     "@terascope/types": "npm:~1.4.4"
@@ -1640,7 +1607,7 @@ __metadata:
     ip-cidr: "npm:~4.0.2"
     ip6addr: "npm:~0.2.5"
     ipaddr.js: "npm:~2.2.0"
-    is-cidr: "npm:~5.1.1"
+    is-cidr: "npm:~6.0.0"
     is-plain-object: "npm:~5.0.0"
     js-string-escape: "npm:~1.0.1"
     kind-of: "npm:~6.0.3"
@@ -1650,7 +1617,7 @@ __metadata:
     p-map: "npm:~7.0.3"
     shallow-clone: "npm:~3.0.1"
     validator: "npm:~13.12.0"
-  checksum: 10c0/40e1fb4562ce14b94ecd13e3bb4b69d696a19eaba5318d7cc9a083ab036346ae7db54501b3204b05ad1ba02a9e34e8252cd0fea19244a05d230141dd94e26200
+  checksum: 10c0/a088410dce937c6a0239966e3f30c13ff29dc3cccefabbc42873926d724507a42f0c1b778893b8dbe165e9801b01bc4d3144d1fb471020050f16b352a2be4683
   languageName: node
   linkType: hard
 
@@ -2098,12 +2065,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~24.2.1":
-  version: 24.2.1
-  resolution: "@types/node@npm:24.2.1"
+"@types/node@npm:~24.3.0":
+  version: 24.3.0
+  resolution: "@types/node@npm:24.3.0"
   dependencies:
     undici-types: "npm:~7.10.0"
-  checksum: 10c0/439a3c7edf88a298e0c92e46f670234070b892589c3b06e82cc86c47a7e1cf220f4a4b4736ec6ac7e4b9e1c40d7b6d443a1e22f99dd17f13f9dd15de3b32011b
+  checksum: 10c0/96bdeca01f690338957c2dcc92cb9f76c262c10398f8d91860865464412b0f9d309c24d9b03d0bdd26dd47fa7ee3f8227893d5c89bc2009d919a525a22512030
   languageName: node
   linkType: hard
 
@@ -3410,12 +3377,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cidr-regex@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "cidr-regex@npm:4.1.1"
+"cidr-regex@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "cidr-regex@npm:5.0.0"
   dependencies:
     ip-regex: "npm:^5.0.0"
-  checksum: 10c0/11433b68346f1029543c6ad03468ab5a4eb96970e381aeba7f6075a73fc8202e37b5547c2be0ec11a4de3aa6b5fff23d8173ff8441276fdde07981b271a54f56
+  checksum: 10c0/39ae6731eb3abe61fd35e5b0603c65a23d7f0d9eb8909c7bc5fa269eee639143b9ca7ddb322b5fffe5e471fd962cd5458bfcee3e4fa3dfc7a4abe4cbef93079a
   languageName: node
   linkType: hard
 
@@ -4380,15 +4347,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-testing-library@npm:~7.6.3":
-  version: 7.6.4
-  resolution: "eslint-plugin-testing-library@npm:7.6.4"
+"eslint-plugin-testing-library@npm:~7.6.4":
+  version: 7.6.6
+  resolution: "eslint-plugin-testing-library@npm:7.6.6"
   dependencies:
     "@typescript-eslint/scope-manager": "npm:^8.15.0"
     "@typescript-eslint/utils": "npm:^8.15.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/e5e9c4169486cf3b71d796cd64b11c1c7906aeed2065ade0461a7e38a37328b9da2414608757996a7a8447d477b1f5329e43fd04297fbebed336be95253a0c2e
+  checksum: 10c0/901b75ccaa106bb988e4eb3580b88b256d35127da616b84959f18686474948060772d80c2c63deebcf2cdcef659ac978026036bc0321b75e6ff3c7d0f13418fe
   languageName: node
   linkType: hard
 
@@ -4420,56 +4387,6 @@ __metadata:
   version: 4.2.1
   resolution: "eslint-visitor-keys@npm:4.2.1"
   checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
-  languageName: node
-  linkType: hard
-
-"eslint@npm:~9.32.0":
-  version: 9.32.0
-  resolution: "eslint@npm:9.32.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.21.0"
-    "@eslint/config-helpers": "npm:^0.3.0"
-    "@eslint/core": "npm:^0.15.0"
-    "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.32.0"
-    "@eslint/plugin-kit": "npm:^0.3.4"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.2"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.4.0"
-    eslint-visitor-keys: "npm:^4.2.1"
-    espree: "npm:^10.4.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/e8a23924ec5f8b62e95483002ca25db74e25c23bd9c6d98a9f656ee32f820169bee3bfdf548ec728b16694f198b3db857d85a49210ee4a035242711d08fdc602
   languageName: node
   linkType: hard
 
@@ -5743,12 +5660,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-cidr@npm:~5.1.1":
-  version: 5.1.1
-  resolution: "is-cidr@npm:5.1.1"
+"is-cidr@npm:~6.0.0":
+  version: 6.0.0
+  resolution: "is-cidr@npm:6.0.0"
   dependencies:
-    cidr-regex: "npm:^4.1.1"
-  checksum: 10c0/79624e7a778f3b9f7d9d22e258b3dce6552d47a094663f038d40dfa12df4855b951087257e658602735814c1046d432710e94fda707040e2a43c57e18909742d
+    cidr-regex: "npm:^5.0.0"
+  checksum: 10c0/3d07ca7b2f0ba875c40c27c2f4af975609e57a98ca3f37da4da679670e13d84d8db7adbc5a5dead360646b053ecf03f2ac59c15fedfe0a67d9df9f911d2a359d
   languageName: node
   linkType: hard
 
@@ -6853,12 +6770,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kafka-asset-bundle@workspace:."
   dependencies:
-    "@terascope/eslint-config": "npm:~1.1.22"
-    "@terascope/job-components": "npm:~1.12.1"
-    "@terascope/scripts": "npm:~1.21.1"
+    "@terascope/eslint-config": "npm:~1.1.23"
+    "@terascope/job-components": "npm:~1.12.2"
+    "@terascope/scripts": "npm:~1.21.3"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~30.0.0"
-    "@types/node": "npm:~24.2.1"
+    "@types/node": "npm:~24.3.0"
     "@types/semver": "npm:~7.7.0"
     "@types/uuid": "npm:~10.0.0"
     bunyan: "npm:~1.8.15"
@@ -6879,7 +6796,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kafka-assets@workspace:asset"
   dependencies:
-    "@terascope/job-components": "npm:~1.12.1"
+    "@terascope/job-components": "npm:~1.12.2"
     "@terascope/types": "npm:~1.4.4"
   languageName: unknown
   linkType: soft
@@ -9241,8 +9158,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector"
   dependencies:
-    "@terascope/job-components": "npm:~1.12.1"
-    "@terascope/scripts": "npm:~1.21.1"
+    "@terascope/job-components": "npm:~1.12.2"
+    "@terascope/scripts": "npm:~1.21.3"
     "@types/convict": "npm:~6.1.6"
     convict: "npm:~6.2.4"
     node-rdkafka: "npm:~3.4.1"
@@ -9526,7 +9443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:~0.28.9":
+"typedoc@npm:~0.28.10":
   version: 0.28.10
   resolution: "typedoc@npm:0.28.10"
   dependencies:


### PR DESCRIPTION
This PR updates the following packages:
# kafka-assets
  - dependencies
    - @terascope/job-components from 1.12.1 to 1.12.2
# kafka-asset-bundle
  - devDependencies
    - @terascope/eslint-config from 1.1.22 to 1.1.23
    - @terascope/job-components from 1.12.1 to 1.12.2
    - @terascope/scripts from 1.21.1 to 1.21.3
    - @types/node from 24.2.1 to 24.3.0
# terafoundation_kafka_connector
  - devDependencies
    - @terascope/job-components from 1.12.1 to 1.12.2
    - @terascope/scripts from 1.21.1 to 1.21.3