### PR TITLE
Bump node-rdkafka to version 3.5.0

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.8.4",
+    "version": "5.9.0",
     "minimum_teraslice_version": "2.9.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.8.4",
+    "version": "5.9.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.8.4",
+    "version": "5.9.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",
@@ -52,7 +52,7 @@
         "jest": "~30.0.5",
         "jest-extended": "~6.0.0",
         "semver": "~7.7.2",
-        "terafoundation_kafka_connector": "~1.5.1",
+        "terafoundation_kafka_connector": "~1.6.0",
         "teraslice-test-harness": "~1.3.7",
         "ts-jest": "~29.4.1",
         "typescript": "~5.9.2",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -22,7 +22,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "node-rdkafka": "~3.4.1"
+        "node-rdkafka": "~3.5.0"
     },
     "devDependencies": {
         "@terascope/job-components": "~1.12.2",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation_kafka_connector",
     "displayName": "Terafoundation Kafka Connector",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "homepage": "https://github.com/terascope/kafka-assets",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7460,14 +7460,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-rdkafka@npm:~3.4.1":
-  version: 3.4.1
-  resolution: "node-rdkafka@npm:3.4.1"
+"node-rdkafka@npm:~3.5.0":
+  version: 3.5.0
+  resolution: "node-rdkafka@npm:3.5.0"
   dependencies:
     bindings: "npm:^1.3.1"
     nan: "npm:^2.22.0"
     node-gyp: "npm:latest"
-  checksum: 10c0/414ecd9887a469fefc1cf553f5df3629726a83e6371ee85a2b6c0dc020203e6797355f3557d28ed20b8fa20900de822e9268bc08678afd2b03629d988685950d
+  checksum: 10c0/8b5ff93a4d9b15b11bbafb5d96bb5cae25bc8cb4b876b87803b098fa1fd04604ccab9394f3a6f6ef44cf194868c9d96224182242ef21d26decd7e6ad8e75d76e
   languageName: node
   linkType: hard
 
@@ -9219,7 +9219,7 @@ __metadata:
     "@terascope/scripts": "npm:~1.21.4"
     "@types/convict": "npm:~6.1.6"
     convict: "npm:~6.2.4"
-    node-rdkafka: "npm:~3.4.1"
+    node-rdkafka: "npm:~3.5.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6841,7 +6841,7 @@ __metadata:
     jest: "npm:~30.0.5"
     jest-extended: "npm:~6.0.0"
     semver: "npm:~7.7.2"
-    terafoundation_kafka_connector: "npm:~1.5.1"
+    terafoundation_kafka_connector: "npm:~1.6.0"
     teraslice-test-harness: "npm:~1.3.7"
     ts-jest: "npm:~29.4.1"
     typescript: "npm:~5.9.2"
@@ -9211,7 +9211,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation_kafka_connector@npm:~1.5.1, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
+"terafoundation_kafka_connector@npm:~1.6.0, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
   version: 0.0.0-use.local
   resolution: "terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector"
   dependencies:


### PR DESCRIPTION
This PR updates the following packages:
# kafka-asset-bundle from 5.8.4 to 5.9.0
  - devDependencies
    - terafoundation_kafka_connector from 1.5.1 to 1.6.0
# terafoundation_kafka_connector from 1.5.1 to 1.6.0
  - dependencies
    - node-rdkafka from 3.4.1 to 3.5.0
      - this version bumps librdkafka from 2.10.1 to 2.11.0