### PR TITLE
add rdkafka settings

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "5.9.0",
+    "version": "5.10.0",
     "minimum_teraslice_version": "2.9.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "5.9.0",
+    "version": "5.10.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/asset/src/kafka_reader_api/api.ts
+++ b/asset/src/kafka_reader_api/api.ts
@@ -66,7 +66,6 @@ export default class KafkaReaderApi extends APIFactory<APIConsumer, KafkaReaderA
         if (assignmentStrategy) {
             config.rdkafka_options['partition.assignment.strategy'] = assignmentStrategy;
         }
-        console.log('rdkafka_options: ', config.rdkafka_options);
         return config as ConnectionConfig;
     }
 

--- a/asset/src/kafka_reader_api/api.ts
+++ b/asset/src/kafka_reader_api/api.ts
@@ -27,7 +27,11 @@ export default class KafkaReaderApi extends APIFactory<APIConsumer, KafkaReaderA
         if (isNil(config.rollback_on_failure) || !isBoolean(config.rollback_on_failure)) throw new Error(`Parameter rollback_on_failure must be provided and be of type boolean, got ${getTypeOf(config.rollback_on_failure)}`);
         if (isNil(config.partition_assignment_strategy) || !isString(config.partition_assignment_strategy)) throw new Error(`Parameter partition_assignment_strategy must be provided and be of type string, got ${getTypeOf(config.partition_assignment_strategy)}`);
         if (isNotNil(config._encoding) && !isString(config._encoding)) throw new Error(`Parameter _encoding must be provided and be of type string, got ${getTypeOf(config._encoding)}`);
-        if (isNil(config.rdkafka_options) || !isObjectEntity(config.rdkafka_options)) throw new Error(`Parameter rdkafka_options must be provided and be of type object, got ${getTypeOf(config.rdkafka_options)}`);
+        // Since we don't validate this key with convict
+        // we don't have the benifit of setting a default. So we set it here
+        if (isNil(config.rdkafka_options) || !isObjectEntity(config.rdkafka_options)) {
+            config.rdkafka_options = {};
+        }
         return config as KafkaReaderAPIConfig;
     }
 

--- a/asset/src/kafka_reader_api/api.ts
+++ b/asset/src/kafka_reader_api/api.ts
@@ -7,7 +7,8 @@ import {
     isString,
     getTypeOf,
     isNumber,
-    isBoolean
+    isBoolean,
+    isObjectEntity
 } from '@terascope/job-components';
 import { APIConsumer } from '../_kafka_clients/index.js';
 import { KafkaReaderConfig } from '../kafka_reader/interfaces.js';
@@ -26,6 +27,7 @@ export default class KafkaReaderApi extends APIFactory<APIConsumer, KafkaReaderA
         if (isNil(config.rollback_on_failure) || !isBoolean(config.rollback_on_failure)) throw new Error(`Parameter rollback_on_failure must be provided and be of type boolean, got ${getTypeOf(config.rollback_on_failure)}`);
         if (isNil(config.partition_assignment_strategy) || !isString(config.partition_assignment_strategy)) throw new Error(`Parameter partition_assignment_strategy must be provided and be of type string, got ${getTypeOf(config.partition_assignment_strategy)}`);
         if (isNotNil(config._encoding) && !isString(config._encoding)) throw new Error(`Parameter _encoding must be provided and be of type string, got ${getTypeOf(config._encoding)}`);
+        if (isNil(config.rdkafka_options) || !isObjectEntity(config.rdkafka_options)) throw new Error(`Parameter rdkafka_options must be provided and be of type object, got ${getTypeOf(config.rdkafka_options)}`);
         return config as KafkaReaderAPIConfig;
     }
 
@@ -55,6 +57,7 @@ export default class KafkaReaderApi extends APIFactory<APIConsumer, KafkaReaderA
                 // Enable partition EOF because node-rdkafka
                 // requires this work for consuming batches
                 'enable.partition.eof': true,
+                ...kafkaConfig.rdkafka_options
             } as Record<string, any>,
             autoconnect: false
         };
@@ -63,7 +66,7 @@ export default class KafkaReaderApi extends APIFactory<APIConsumer, KafkaReaderA
         if (assignmentStrategy) {
             config.rdkafka_options['partition.assignment.strategy'] = assignmentStrategy;
         }
-
+        console.log('rdkafka_options: ', config.rdkafka_options);
         return config as ConnectionConfig;
     }
 

--- a/asset/src/kafka_reader_api/api.ts
+++ b/asset/src/kafka_reader_api/api.ts
@@ -76,13 +76,15 @@ export default class KafkaReaderApi extends APIFactory<APIConsumer, KafkaReaderA
     async create(
         _name: string, config: Partial<KafkaReaderConfig> = {}
     ): Promise<{ client: APIConsumer; config: KafkaReaderAPIConfig }> {
-        const { logger } = this;
+        const logger = config.logger || this.logger;
         const newConfig = Object.assign(
             {}, this.apiConfig, config, { logger }
         );
 
         const validConfig = this.validateConfig(newConfig);
         const clientConfig = this.clientConfig(validConfig);
+
+        logger.debug(`Kafka Consumer Client Configuration: \n${JSON.stringify(clientConfig, null, 2)}`);
 
         const { client: kafkaClient } = await this.context.apis.foundation.createClient(
             clientConfig

--- a/asset/src/kafka_reader_api/schema.ts
+++ b/asset/src/kafka_reader_api/schema.ts
@@ -71,6 +71,10 @@ export const schema = {
         doc: 'Name of partition assignment strategy to use when elected group leader assigns partitions to group members.',
         default: '',
         format: ['range', 'roundrobin', 'cooperative-sticky', '']
+    },
+    rdkafka_options: {
+        doc: 'librdkafka defined settings that are not subscription specific. Settings here will override other settings.',
+        default: {}
     }
 };
 

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -3,6 +3,7 @@ import {
     BatchProcessor,
     Context,
     Logger,
+    makeExContextLogger
 } from '@terascope/job-components';
 import { ExecutionConfig } from '@terascope/types';
 import { KafkaSenderConfig } from './interfaces.js';
@@ -28,7 +29,6 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
     topicMap: TopicMap = new Map();
     connectorDict: ConnectorMap = new Map();
     hasConnectionMap = false;
-    kafkaLogger: Logger;
     api!: KafkaRouteSender;
 
     constructor(
@@ -37,13 +37,14 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
         executionConfig: ExecutionConfig
     ) {
         super(context, opConfig, executionConfig);
-
-        const logger = this.logger.child({ module: 'kafka-producer' });
-        this.kafkaLogger = logger;
     }
 
     async initialize(): Promise<void> {
         await super.initialize();
+
+        // TODO: This should be in the context but doesn't seem to work at the moment
+        const kafkaLogger: Logger = makeExContextLogger(this.context, this.executionConfig, 'kafka-producer');
+
         let apiName = DEFAULT_API_NAME;
         let apiTopic: string | undefined;
         let apiConnection: string | undefined;
@@ -67,7 +68,7 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
             {
                 connection,
                 topic,
-                logger: this.kafkaLogger
+                logger: kafkaLogger
             }
         );
 

--- a/asset/src/kafka_sender_api/api.ts
+++ b/asset/src/kafka_sender_api/api.ts
@@ -84,6 +84,8 @@ export default class KafkaSenderApi extends APIFactory<KafkaRouteSender, KafkaSe
         const validConfig = this.validateConfig(newConfig);
         const clientConfig = this.clientConfig(validConfig);
 
+        logger.debug(`Kafka Producer Client Configuration: \n${JSON.stringify(clientConfig, null, 2)}`);
+
         const { client: kafkaClient } = await this.context.apis.foundation.createClient(
             clientConfig
         );

--- a/asset/src/kafka_sender_api/api.ts
+++ b/asset/src/kafka_sender_api/api.ts
@@ -62,7 +62,6 @@ export default class KafkaSenderApi extends APIFactory<KafkaRouteSender, KafkaSe
             } as Record<string, any>,
             autoconnect: false
         };
-        console.log('rdkafka_options: ', config.rdkafka_options);
         return config as ConnectionConfig;
     }
 

--- a/asset/src/kafka_sender_api/api.ts
+++ b/asset/src/kafka_sender_api/api.ts
@@ -28,8 +28,11 @@ export default class KafkaSenderApi extends APIFactory<KafkaRouteSender, KafkaSe
         if (isNil(config.metadata_refresh) || !isNumber(config.metadata_refresh)) throw new Error(`Parameter metadata_refresh must be provided and be of type number, got ${getTypeOf(config.metadata_refresh)}`);
         if (isNil(config.required_acks) || !isNumber(config.required_acks)) throw new Error(`Parameter required_acks must be provided and be of type number, got ${getTypeOf(config.required_acks)}`);
         if (isNil(config.logger)) throw new Error(`Parameter logger must be provided and be of type Logger, got ${getTypeOf(config.logger)}`);
-        if (isNil(config.rdkafka_options) || !isObjectEntity(config.rdkafka_options)) throw new Error(`Parameter rdkafka_options must be provided and be of type object, got ${getTypeOf(config.rdkafka_options)}`);
-
+        // Since we don't validate this key with convict
+        // we don't have the benifit of setting a default. So we set it here
+        if (isNil(config.rdkafka_options) || !isObjectEntity(config.rdkafka_options)) {
+            config.rdkafka_options = {};
+        }
         // maxBufferLength is used as an indicator of when to flush the queue in producer-client.ts
         // in addition to the max.messages setting
         config.maxBufferLength = config.max_buffer_size;

--- a/asset/src/kafka_sender_api/schema.ts
+++ b/asset/src/kafka_sender_api/schema.ts
@@ -2,7 +2,8 @@ import {
     ConvictSchema,
     AnyObject,
     isNumber,
-    getTypeOf
+    getTypeOf,
+    isPlainObject
 } from '@terascope/job-components';
 
 export const DEFAULT_API_NAME = 'kafka_sender_api';
@@ -88,11 +89,31 @@ export const schema = {
     },
     rdkafka_options: {
         doc: 'librdkafka defined settings that are not subscription specific. Settings here will override other settings.',
-        default: {}
+        default: {},
+        format: (val: any) => {
+            if (!isPlainObject(val)) {
+                throw new Error('Invalid parameter rdkafka_options, it must be an object');
+            }
+        }
     }
 };
 
 export default class Schema extends ConvictSchema<AnyObject> {
+    // This validation function is a workaround for the limitations of convict when
+    // parsing configs that have periods `.` within its key values.
+    // https://github.com/mozilla/node-convict/issues/250
+    // This will pull `rdkafka_options` out before convict validation
+    // https://github.com/terascope/kafka-assets/pull/1071
+    validate(config: Record<string, any>): any {
+        const { rdkafka_options, ...parsedConfig } = config;
+        const results = super.validate(parsedConfig);
+
+        return {
+            ...results,
+            rdkafka_options
+        };
+    }
+
     build(): Record<string, any> {
         return schema;
     }

--- a/asset/src/kafka_sender_api/schema.ts
+++ b/asset/src/kafka_sender_api/schema.ts
@@ -85,6 +85,10 @@ export const schema = {
         doc: 'The number of required broker acknowledgements for a given request, set to -1 for all.',
         default: 1,
         format: 'int'
+    },
+    rdkafka_options: {
+        doc: 'librdkafka defined settings that are not subscription specific. Settings here will override other settings.',
+        default: {}
     }
 };
 

--- a/docs/asset/apis/kafka_reader_api.md
+++ b/docs/asset/apis/kafka_reader_api.md
@@ -212,6 +212,7 @@ const results = await api.consume(query)
 | use_commit_sync | Use commit sync instead of async (usually not recommended) | Boolean | optional, defaults to `false` |
 | wait |How long to wait for a full chunk of data to be available. Specified in milliseconds if you use a number. | String/Duration/Number | optional, defaults to `30 seconds` |
 | _encoding | Used for specifying the data encoding type when using DataEntity.fromBuffer. May be set to `json` or `raw` | String | optional, defaults to `json` |
+| rdkafka_options | [librdkafka defined settings](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) that are not subscription specific. **Settings here will override other settings.** | Object | optional, default to `{}` |
 
 ### Metadata
 

--- a/docs/asset/apis/kafka_sender_api.md
+++ b/docs/asset/apis/kafka_sender_api.md
@@ -28,7 +28,10 @@ Example Job
             "size": 10000,
             "id_field": "uuid",
             "timestamp_field": "created",
-            "connection": "default"
+            "connection": "default",
+            "rdkafka_options": {
+                "queued.max.messages.kbytes": 65536
+            }
         }
     ],
     "operations" : [
@@ -223,3 +226,4 @@ await api.send([
 | metadata_refresh | How often the producer will poll the broker for metadata information. Set to -1 to disable polling. | String/Duration/Number | optional, defaults to `"5 minutes"` |
 | api_name | Name of `kafka_sender_api` used for the sender, if none is provided, then one is made and assigned the name to `kafka_sender_api`, and is injected into the execution | String | optional, defaults to `kafka_sender_api`|
 | _encoding | Used for specifying the data encoding type when using DataEntity.fromBuffer. May be set to `json` or `raw` | String | optional, defaults to `json` |
+| rdkafka_options | [librdkafka defined settings](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) that are not subscription specific. **Settings here will override other settings.** | Object | optional, default to `{}` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "5.9.0",
+    "version": "5.10.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",

--- a/test/kafka_reader_api/schema-spec.ts
+++ b/test/kafka_reader_api/schema-spec.ts
@@ -77,5 +77,10 @@ describe('Kafka Reader API Schema', () => {
             await expect(makeTest({ offset_reset: -1231 })).toReject();
             await expect(makeTest({ offset_reset: 'hello' })).toReject();
         });
+
+        it('should allow valid rdkafka_options config', async () => {
+            await expect(makeTest({ topic: 'test', group: 'testgroup', rdkafka_options: { 'queued.max.messages.kbytes': 540000 } })).toResolve();
+            await expect(makeTest({ topic: 'test', group: 'testgroup', rdkafka_options: {} })).toResolve();
+        });
     });
 });

--- a/test/kafka_sender_api/schema-spec.ts
+++ b/test/kafka_sender_api/schema-spec.ts
@@ -86,5 +86,10 @@ describe('Kafka Sender API Schema', () => {
                 required_acks: 1
             });
         });
+
+        it('should allow valid rdkafka_options config', async () => {
+            await expect(makeTest({ topic: 'test', rdkafka_options: { 'queue.buffering.max.kbytes': 540000 } })).toResolve();
+            await expect(makeTest({ topic: 'test', rdkafka_options: {} })).toResolve();
+        });
     });
 });


### PR DESCRIPTION
This PR makes the following changes:

- Adds new job option `rdkafka_options` to kafka reader and sender apis
  - This allows for setting global kafka config properties through a job configuration
  - https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
  - Adds testing for `rdkafka_options`
- Bumps Kafka-Asset from `v5.9.0` to `v5.10.0`
- Fixes logging within `kafka_sender` and `kafka_reader`
  - Adds Kafka consumer and producer configuration debug logs 