### PR TITLE
bundled dependency updates for 10-27-2025

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@terascope/scripts": "~1.21.8",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
-        "@types/node": "~24.8.1",
+        "@types/node": "~24.9.1",
         "@types/semver": "~7.7.1",
         "bunyan": "~1.8.15",
         "eslint": "~9.38.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,12 +2129,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~24.8.1":
-  version: 24.8.1
-  resolution: "@types/node@npm:24.8.1"
+"@types/node@npm:~24.9.1":
+  version: 24.9.1
+  resolution: "@types/node@npm:24.9.1"
   dependencies:
-    undici-types: "npm:~7.14.0"
-  checksum: 10c0/d185f2f14aa26cc2b482aa730bfc452943f9636df37aad6ceed80aa397f1278f894043336bd72f74c47b3dbef23e772ac9b1a256168984aa8aee26836132d290
+    undici-types: "npm:~7.16.0"
+  checksum: 10c0/c52f8168080ef9a7c3dc23d8ac6061fab5371aad89231a0f6f4c075869bc3de7e89b075b1f3e3171d9e5143d0dda1807c3dab8e32eac6d68f02e7480e7e78576
   languageName: node
   linkType: hard
 
@@ -6890,7 +6890,7 @@ __metadata:
     "@terascope/scripts": "npm:~1.21.8"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~30.0.0"
-    "@types/node": "npm:~24.8.1"
+    "@types/node": "npm:~24.9.1"
     "@types/semver": "npm:~7.7.1"
     bunyan: "npm:~1.8.15"
     eslint: "npm:~9.38.0"
@@ -9689,10 +9689,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~7.14.0":
-  version: 7.14.0
-  resolution: "undici-types@npm:7.14.0"
-  checksum: 10c0/e7f3214b45d788f03c51ceb33817be99c65dae203863aa9386b3ccc47201a245a7955fc721fb581da9c888b6ebad59fa3f53405214afec04c455a479908f0f14
+"undici-types@npm:~7.16.0":
+  version: 7.16.0
+  resolution: "undici-types@npm:7.16.0"
+  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the following packages:
# kafka-asset-bundle
  - devDependencies
    - @types/node from 24.8.1 to 24.9.1