### PR TITLE
bundled dependency updates for 01-26-2026

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "minimum_teraslice_version": "3.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",
@@ -52,7 +52,7 @@
         "jest": "~30.2.0",
         "jest-extended": "~7.0.0",
         "semver": "~7.7.3",
-        "terafoundation_kafka_connector": "~2.0.0",
+        "terafoundation_kafka_connector": "~2.0.1",
         "teraslice-test-harness": "~2.0.3",
         "ts-jest": "~29.4.6",
         "typescript": "~5.9.3",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation_kafka_connector",
     "displayName": "Terafoundation Kafka Connector",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "homepage": "https://github.com/terascope/kafka-assets",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6465,7 +6465,7 @@ __metadata:
     jest: "npm:~30.2.0"
     jest-extended: "npm:~7.0.0"
     semver: "npm:~7.7.3"
-    terafoundation_kafka_connector: "npm:~2.0.0"
+    terafoundation_kafka_connector: "npm:~2.0.1"
     teraslice-test-harness: "npm:~2.0.3"
     ts-jest: "npm:~29.4.6"
     typescript: "npm:~5.9.3"
@@ -8830,7 +8830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation_kafka_connector@npm:~2.0.0, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
+"terafoundation_kafka_connector@npm:~2.0.1, terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector":
   version: 0.0.0-use.local
   resolution: "terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector"
   dependencies:


### PR DESCRIPTION
This PR updates the following packages:
# kafka-assets from 6.0.0 to 6.0.1
  - dependencies
    - @terascope/core-utils from 2.0.0 to 2.0.3
    - @terascope/job-components from 2.0.0 to 2.0.3
    - @terascope/types from 2.0.0 to 2.0.1
# kafka-asset-bundle from 6.0.0 to 6.0.1
  - devDependencies
    - @terascope/core-utils from 2.0.0 to 2.0.3
    - @terascope/eslint-config from 1.1.26 to 1.1.27
    - @terascope/job-components from 2.0.0 to 2.0.3
    - @terascope/scripts from 2.0.1 to 2.0.5
    - teraslice-test-harness from 2.0.0 to 2.0.3
# terafoundation_kafka_connector from 2.0.0 to 2.0.1
  - devDependencies
    - @terascope/core-utils from 2.0.0 to 2.0.3
    - @terascope/job-components from 2.0.0 to 2.0.3
    - @terascope/scripts from 2.0.1 to 2.0.5