### PR TITLE
bundled dependency updates for 03-02-2026

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -22,8 +22,8 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@terascope/core-utils": "~2.2.1",
-        "@terascope/job-components": "~2.2.1",
+        "@terascope/core-utils": "~2.2.2",
+        "@terascope/job-components": "~2.2.2",
         "@terascope/types": "~2.2.1"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
-        "@terascope/core-utils": "~2.2.1",
+        "@terascope/core-utils": "~2.2.2",
         "@terascope/eslint-config": "~1.1.29",
-        "@terascope/job-components": "~2.2.1",
-        "@terascope/scripts": "~2.2.1",
+        "@terascope/job-components": "~2.2.2",
+        "@terascope/scripts": "~2.2.2",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
-        "@types/node": "~24.10.13",
+        "@types/node": "~24.10.15",
         "@types/semver": "~7.7.1",
         "bunyan": "~1.8.15",
         "eslint": "~9.39.3",
@@ -53,7 +53,7 @@
         "jest-extended": "~7.0.0",
         "semver": "~7.7.4",
         "terafoundation_kafka_connector": "~2.1.0",
-        "teraslice-test-harness": "~2.2.1",
+        "teraslice-test-harness": "~2.2.2",
         "ts-jest": "~29.4.6",
         "typescript": "~5.9.3",
         "uuid": "~13.0.0"

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -25,9 +25,9 @@
         "@confluentinc/kafka-javascript": "~1.8.0"
     },
     "devDependencies": {
-        "@terascope/core-utils": "~2.2.1",
-        "@terascope/job-components": "~2.2.1",
-        "@terascope/scripts": "~2.2.1",
+        "@terascope/core-utils": "~2.2.2",
+        "@terascope/job-components": "~2.2.2",
+        "@terascope/scripts": "~2.2.2",
         "@types/convict": "~6.1.6",
         "convict": "~6.2.4"
     },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6573,6 +6573,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "brace-expansion@npm:2.0.2"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^5.0.2":
   version: 5.0.3
   resolution: "brace-expansion@npm:5.0.3"
@@ -11699,20 +11708,20 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^10.2.1":
-  version: 10.2.2
-  resolution: "minimatch@npm:10.2.2"
+  version: 10.2.4
+  resolution: "minimatch@npm:10.2.4"
   dependencies:
     brace-expansion: "npm:^5.0.2"
-  checksum: 10c0/098831f2f542cb802e1f249c809008a016e1fef6b3a9eda9cf9ecb2b3d7979083951bd47c0c82fcf34330bd3b36638a493d4fa8e24cce58caf5b481de0f4e238
+  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
   languageName: node
   linkType: hard
 
 "minimatch@npm:^9.0.4":
-  version: 9.0.6
-  resolution: "minimatch@npm:9.0.6"
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10c0/b81984f96b64b9b3c6cc7d949950290c456639bf5d89c568041b0505080cfe34102bd1d8586a4dc65878ca02e68ac425e0d8fcb7af10156694c4b8889a0c6c75
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,13 +1467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^5.2.0":
-  version: 5.6.0
-  resolution: "@sindresorhus/is@npm:5.6.0"
-  checksum: 10c0/66727344d0c92edde5760b5fd1f8092b717f2298a162a5f7f29e4953e001479927402d9d387e245fb9dc7d3b37c72e335e93ed5875edfc5203c53be8ecba1b52
-  languageName: node
-  linkType: hard
-
 "@sindresorhus/is@npm:^7.0.1":
   version: 7.0.2
   resolution: "@sindresorhus/is@npm:7.0.2"
@@ -1522,21 +1515,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@szmarczak/http-timer@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@szmarczak/http-timer@npm:5.0.1"
-  dependencies:
-    defer-to-connect: "npm:^2.0.1"
-  checksum: 10c0/4629d2fbb2ea67c2e9dc03af235c0991c79ebdddcbc19aed5d5732fb29ce01c13331e9b1a491584b9069bd6ecde6581dcbf871f11b7eefdebbab34de6cf2197e
-  languageName: node
-  linkType: hard
-
-"@terascope/core-utils@npm:~2.2.1":
-  version: 2.2.1
-  resolution: "@terascope/core-utils@npm:2.2.1"
+"@terascope/core-utils@npm:~2.2.2":
+  version: 2.2.2
+  resolution: "@terascope/core-utils@npm:2.2.2"
   dependencies:
     "@terascope/types": "npm:~2.2.1"
-    awesome-phonenumber: "npm:~7.7.0"
+    awesome-phonenumber: "npm:~7.8.0"
     bunyan: "npm:~1.8.15"
     date-fns: "npm:~4.1.0"
     date-fns-tz: "npm:~3.2.0"
@@ -1552,7 +1536,7 @@ __metadata:
     shallow-clone: "npm:~3.0.1"
     validator: "npm:~13.15.26"
     zod: "npm:~4.1.12"
-  checksum: 10c0/41d4e71661f691f8dac59cf7442905ce433ae76cf60f183edd85587c05fab8abff645981ee714f1edabcb48ca7c71343eaa56515e329d5d9dfbc82a3e2e0d40f
+  checksum: 10c0/49d19220029cfbcef3a68e07a86947cf981bbf5f1b67075643fb8fe5f7e801fe96391399908f5aa382826aa4e3cebb3362e6a983856d4703c4968d98201c5cae
   languageName: node
   linkType: hard
 
@@ -1580,44 +1564,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/fetch-github-release@npm:~2.2.1":
-  version: 2.2.1
-  resolution: "@terascope/fetch-github-release@npm:2.2.1"
+"@terascope/fetch-github-release@npm:~2.2.2":
+  version: 2.2.2
+  resolution: "@terascope/fetch-github-release@npm:2.2.2"
   dependencies:
     extract-zip: "npm:^2.0.1"
-    got: "npm:13.0.0"
+    got: "npm:14.6.6"
     multi-progress: "npm:^4.0.0"
     progress: "npm:^2.0.3"
-    yargs: "npm:^17.7.2"
+    yargs: "npm:^18.0.0"
   bin:
     fetch-github-release: bin/fetch-github-release
-  checksum: 10c0/531243e8ea615a078a146312d6723dbb53019116eeb0b6ba90e6f32e1513fed6c9d999400feb0db0ccbc4f3fbef2f20ec84b15cfa405951160c6710d0b4500bc
+  checksum: 10c0/0da12b3525a1556f23d03f8da23477fda35d79605754e92ee6ccf15e561fabab4f9b6007e461943dfc8259c3fbb5f6ad912f62f35253cb5b76b79633482c7253
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~2.2.1":
-  version: 2.2.1
-  resolution: "@terascope/job-components@npm:2.2.1"
+"@terascope/job-components@npm:~2.2.2":
+  version: 2.2.2
+  resolution: "@terascope/job-components@npm:2.2.2"
   dependencies:
-    "@terascope/core-utils": "npm:~2.2.1"
+    "@terascope/core-utils": "npm:~2.2.2"
     "@terascope/types": "npm:~2.2.1"
     import-meta-resolve: "npm:~4.2.0"
     prom-client: "npm:~15.1.3"
-    semver: "npm:~7.7.3"
+    semver: "npm:~7.7.4"
     uuid: "npm:~13.0.0"
-  checksum: 10c0/d81d404c3d5a3a92ee55a9eacb679b28fb4d0f8db44295db4150b364757e740d5d2aef213d494ad2bbc356ddc579dd5f7e576042151f9182a8088ddd524bf6bd
+  checksum: 10c0/d4c65d780b61b214c2ca7554db9dee1b99da4316b855000742e92df88856e805f0f942ae339fb6dc1900f07f8f06c3c150af7bf2c3cdea563a17df349f6a25eb
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~2.2.1":
-  version: 2.2.1
-  resolution: "@terascope/scripts@npm:2.2.1"
+"@terascope/scripts@npm:~2.2.2":
+  version: 2.2.2
+  resolution: "@terascope/scripts@npm:2.2.2"
   dependencies:
     "@kubernetes/client-node": "npm:~1.4.0"
-    "@terascope/core-utils": "npm:~2.2.1"
+    "@terascope/core-utils": "npm:~2.2.2"
     execa: "npm:~9.6.1"
     fs-extra: "npm:~11.3.3"
-    globby: "npm:~16.1.0"
+    globby: "npm:~16.1.1"
     got: "npm:~14.6.6"
     ip: "npm:~2.0.1"
     js-yaml: "npm:~4.1.1"
@@ -1627,12 +1611,12 @@ __metadata:
     ms: "npm:~2.1.3"
     package-json: "npm:~10.0.1"
     package-up: "npm:~5.0.0"
-    semver: "npm:~7.7.3"
+    semver: "npm:~7.7.4"
     signale: "npm:~1.4.0"
     sort-package-json: "npm:~3.6.1"
     toposort: "npm:~2.0.2"
-    typedoc: "npm:~0.28.16"
-    typedoc-plugin-markdown: "npm:~4.9.0"
+    typedoc: "npm:~0.28.17"
+    typedoc-plugin-markdown: "npm:~4.10.0"
     yaml: "npm:~2.8.2"
     yargs: "npm:~18.0.0"
   peerDependencies:
@@ -1642,7 +1626,7 @@ __metadata:
       optional: true
   bin:
     ts-scripts: bin/ts-scripts.js
-  checksum: 10c0/ca1661d9edc5220b674c8e324052655557bb934bb1438ab69fb113decdca3479d40985c4fa737c8d7045109fa5fe7fe82b811f976b32d5cb3ed163139c0226d0
+  checksum: 10c0/799ca7ed164365bec78de4e537d4e73d552107d05655ee68ddba2fe9abfe73fa7b515f159ead63ec434dea38f5061a3aee39ad39f5b14c0578619df2ac46e57c
   languageName: node
   linkType: hard
 
@@ -1740,7 +1724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/http-cache-semantics@npm:^4.0.2, @types/http-cache-semantics@npm:^4.0.4":
+"@types/http-cache-semantics@npm:^4.0.4":
   version: 4.0.4
   resolution: "@types/http-cache-semantics@npm:4.0.4"
   checksum: 10c0/51b72568b4b2863e0fe8d6ce8aad72a784b7510d72dc866215642da51d84945a9459fa89f49ec48f1e9a1752e6a78e85a4cda0ded06b1c73e727610c925f9ce6
@@ -1840,12 +1824,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~24.10.13":
-  version: 24.10.13
-  resolution: "@types/node@npm:24.10.13"
+"@types/node@npm:~24.10.15":
+  version: 24.10.15
+  resolution: "@types/node@npm:24.10.15"
   dependencies:
     undici-types: "npm:~7.16.0"
-  checksum: 10c0/4ff0b9b060b5477c0fec5b11a176f294be588104ab546295db65b17a92ba0a6077b52ad92dd3c0d2154198c7f9d0021e6c1d42b00c9ac7ebfd85632afbcc48a4
+  checksum: 10c0/5c688efe22b660fa1f21a4c8b1b9c9deae7db7f174e1c4c82799e6395ebfcdf5b97dac137814616be167e636ae77a4ffa5d9e871cbe6796811abea3628ff6dda
   languageName: node
   linkType: hard
 
@@ -2650,10 +2634,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"awesome-phonenumber@npm:~7.7.0":
-  version: 7.7.0
-  resolution: "awesome-phonenumber@npm:7.7.0"
-  checksum: 10c0/417190ed7993a0a2f0341c3602bdb39a4d299c3d11a22c80c4df5caa0f0c99cde91990ff047b4ee070e1d0c153fc42a1ee74b84be01df33782ab35f65f9f4e00
+"awesome-phonenumber@npm:~7.8.0":
+  version: 7.8.0
+  resolution: "awesome-phonenumber@npm:7.8.0"
+  checksum: 10c0/33b06a46ebaea6fe00f5c159cbc972e5acf827439d00b8234ded44d96b255cb97a2ce98684236236c4ad946919000b28ed7d2ad9ed4a3c56123fb515feb1f4bb
   languageName: node
   linkType: hard
 
@@ -2860,12 +2844,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "brace-expansion@npm:2.0.1"
+"brace-expansion@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "brace-expansion@npm:2.0.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/b358f2fe060e2d7a87aa015979ecea07f3c37d4018f8d6deb5bd4c229ad3a0384fe6029bb76cd8be63c81e516ee52d1a0673edbe2023d53a5191732ae3c3e49f
+  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
   languageName: node
   linkType: hard
 
@@ -3012,21 +2996,6 @@ __metadata:
   version: 7.0.0
   resolution: "cacheable-lookup@npm:7.0.0"
   checksum: 10c0/63a9c144c5b45cb5549251e3ea774c04d63063b29e469f7584171d059d3a88f650f47869a974e2d07de62116463d742c287a81a625e791539d987115cb081635
-  languageName: node
-  linkType: hard
-
-"cacheable-request@npm:^10.2.8":
-  version: 10.2.14
-  resolution: "cacheable-request@npm:10.2.14"
-  dependencies:
-    "@types/http-cache-semantics": "npm:^4.0.2"
-    get-stream: "npm:^6.0.1"
-    http-cache-semantics: "npm:^4.1.1"
-    keyv: "npm:^4.5.3"
-    mimic-response: "npm:^4.0.0"
-    normalize-url: "npm:^8.0.0"
-    responselike: "npm:^3.0.0"
-  checksum: 10c0/41b6658db369f20c03128227ecd219ca7ac52a9d24fc0f499cc9aa5d40c097b48b73553504cebd137024d957c0ddb5b67cf3ac1439b136667f3586257763f88d
   languageName: node
   linkType: hard
 
@@ -3440,15 +3409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decompress-response@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "decompress-response@npm:6.0.0"
-  dependencies:
-    mimic-response: "npm:^3.1.0"
-  checksum: 10c0/bd89d23141b96d80577e70c54fb226b2f40e74a6817652b80a116d7befb8758261ad073a8895648a29cc0a5947021ab66705cb542fa9c143c82022b27c5b175e
-  languageName: node
-  linkType: hard
-
 "decompress-tar@npm:^4.0.0, decompress-tar@npm:^4.1.0, decompress-tar@npm:^4.1.1":
   version: 4.1.1
   resolution: "decompress-tar@npm:4.1.1"
@@ -3542,13 +3502,6 @@ __metadata:
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
-  languageName: node
-  linkType: hard
-
-"defer-to-connect@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "defer-to-connect@npm:2.0.1"
-  checksum: 10c0/625ce28e1b5ad10cf77057b9a6a727bf84780c17660f6644dab61dd34c23de3001f03cedc401f7d30a4ed9965c2e8a7336e220a329146f2cf85d4eddea429782
   languageName: node
   linkType: hard
 
@@ -4656,13 +4609,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data-encoder@npm:^2.1.2":
-  version: 2.1.4
-  resolution: "form-data-encoder@npm:2.1.4"
-  checksum: 10c0/4c06ae2b79ad693a59938dc49ebd020ecb58e4584860a90a230f80a68b026483b022ba5e4143cff06ae5ac8fd446a0b500fabc87bbac3d1f62f2757f8dabcaf7
-  languageName: node
-  linkType: hard
-
 "form-data-encoder@npm:^4.0.2":
   version: 4.1.0
   resolution: "form-data-encoder@npm:4.1.0"
@@ -4896,7 +4842,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
+"get-stream@npm:^6.0.0":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: 10c0/49825d57d3fd6964228e6200a58169464b8e8970489b3acdc24906c782fb7f01f9f56f8e6653c4a50713771d6658f7cfe051e5eb8c12e334138c9c918b296341
@@ -5023,9 +4969,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:~16.1.0":
-  version: 16.1.0
-  resolution: "globby@npm:16.1.0"
+"globby@npm:~16.1.1":
+  version: 16.1.1
+  resolution: "globby@npm:16.1.1"
   dependencies:
     "@sindresorhus/merge-streams": "npm:^4.0.0"
     fast-glob: "npm:^3.3.3"
@@ -5033,7 +4979,7 @@ __metadata:
     is-path-inside: "npm:^4.0.0"
     slash: "npm:^5.1.0"
     unicorn-magic: "npm:^0.4.0"
-  checksum: 10c0/45dd4dd8311401b37ed426ad7ea7a6e8fdda2518bb0d62fbf0a46c2e6b81bcbd2c8d4fbcbcf4c0600bba15c5a8f4621785d0177acbb1b545f02f6b49f2cdbe24
+  checksum: 10c0/2fbed8e5c59639a98b9b9c700afe5bcedf14742b43c25950cfd34a032db0cce4b440d8436beb4a936d211744e0b7330646f086b95cd8054251162c5d83001600
   languageName: node
   linkType: hard
 
@@ -5044,26 +4990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:13.0.0":
-  version: 13.0.0
-  resolution: "got@npm:13.0.0"
-  dependencies:
-    "@sindresorhus/is": "npm:^5.2.0"
-    "@szmarczak/http-timer": "npm:^5.0.1"
-    cacheable-lookup: "npm:^7.0.0"
-    cacheable-request: "npm:^10.2.8"
-    decompress-response: "npm:^6.0.0"
-    form-data-encoder: "npm:^2.1.2"
-    get-stream: "npm:^6.0.1"
-    http2-wrapper: "npm:^2.1.10"
-    lowercase-keys: "npm:^3.0.0"
-    p-cancelable: "npm:^3.0.0"
-    responselike: "npm:^3.0.0"
-  checksum: 10c0/d6a4648dc46f1f9df2637b8730d4e664349a93cb6df62c66dfbb48f7887ba79742a1cc90739a4eb1c15f790ca838ff641c5cdecdc877993627274aeb0f02b92d
-  languageName: node
-  linkType: hard
-
-"got@npm:~14.6.6":
+"got@npm:14.6.6, got@npm:~14.6.6":
   version: 14.6.6
   resolution: "got@npm:14.6.6"
   dependencies:
@@ -5224,7 +5151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http2-wrapper@npm:^2.1.10, http2-wrapper@npm:^2.2.1":
+"http2-wrapper@npm:^2.2.1":
   version: 2.2.1
   resolution: "http2-wrapper@npm:2.2.1"
   dependencies:
@@ -6512,13 +6439,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kafka-asset-bundle@workspace:."
   dependencies:
-    "@terascope/core-utils": "npm:~2.2.1"
+    "@terascope/core-utils": "npm:~2.2.2"
     "@terascope/eslint-config": "npm:~1.1.29"
-    "@terascope/job-components": "npm:~2.2.1"
-    "@terascope/scripts": "npm:~2.2.1"
+    "@terascope/job-components": "npm:~2.2.2"
+    "@terascope/scripts": "npm:~2.2.2"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~30.0.0"
-    "@types/node": "npm:~24.10.13"
+    "@types/node": "npm:~24.10.15"
     "@types/semver": "npm:~7.7.1"
     bunyan: "npm:~1.8.15"
     eslint: "npm:~9.39.3"
@@ -6527,7 +6454,7 @@ __metadata:
     jest-extended: "npm:~7.0.0"
     semver: "npm:~7.7.4"
     terafoundation_kafka_connector: "npm:~2.1.0"
-    teraslice-test-harness: "npm:~2.2.1"
+    teraslice-test-harness: "npm:~2.2.2"
     ts-jest: "npm:~29.4.6"
     typescript: "npm:~5.9.3"
     uuid: "npm:~13.0.0"
@@ -6538,8 +6465,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kafka-assets@workspace:asset"
   dependencies:
-    "@terascope/core-utils": "npm:~2.2.1"
-    "@terascope/job-components": "npm:~2.2.1"
+    "@terascope/core-utils": "npm:~2.2.2"
+    "@terascope/job-components": "npm:~2.2.2"
     "@terascope/types": "npm:~2.2.1"
   languageName: unknown
   linkType: soft
@@ -6551,7 +6478,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.5.3, keyv@npm:^4.5.4":
+"keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:
@@ -6880,13 +6807,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-response@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "mimic-response@npm:3.1.0"
-  checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
-  languageName: node
-  linkType: hard
-
 "mimic-response@npm:^4.0.0":
   version: 4.0.0
   resolution: "mimic-response@npm:4.0.0"
@@ -6895,20 +6815,20 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:2 || 3, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
 "minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 
@@ -7219,13 +7139,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^8.0.0":
-  version: 8.0.1
-  resolution: "normalize-url@npm:8.0.1"
-  checksum: 10c0/eb439231c4b84430f187530e6fdac605c5048ef4ec556447a10c00a91fc69b52d8d8298d9d608e68d3e0f7dc2d812d3455edf425e0f215993667c3183bcab1ef
-  languageName: node
-  linkType: hard
-
 "normalize-url@npm:^8.1.1":
   version: 8.1.1
   resolution: "normalize-url@npm:8.1.1"
@@ -7417,13 +7330,6 @@ __metadata:
     object-keys: "npm:^1.1.1"
     safe-push-apply: "npm:^1.0.0"
   checksum: 10c0/6dfeb3455bff92ec3f16a982d4e3e65676345f6902d9f5ded1d8265a6318d0200ce461956d6d1c70053c7fe9f9fe65e552faac03f8140d37ef0fdd108e67013a
-  languageName: node
-  linkType: hard
-
-"p-cancelable@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "p-cancelable@npm:3.0.0"
-  checksum: 10c0/948fd4f8e87b956d9afc2c6c7392de9113dac817cb1cecf4143f7a3d4c57ab5673614a80be3aba91ceec5e4b69fd8c869852d7e8048bc3d9273c4c36ce14b9aa
   languageName: node
   linkType: hard
 
@@ -8079,15 +7985,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"responselike@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "responselike@npm:3.0.0"
-  dependencies:
-    lowercase-keys: "npm:^3.0.0"
-  checksum: 10c0/8af27153f7e47aa2c07a5f2d538cb1e5872995f0e9ff77def858ecce5c3fe677d42b824a62cde502e56d275ab832b0a8bd350d5cd6b467ac0425214ac12ae658
-  languageName: node
-  linkType: hard
-
 "responselike@npm:^4.0.2":
   version: 4.0.2
   resolution: "responselike@npm:4.0.2"
@@ -8261,7 +8158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.7.3, semver@npm:~7.7.3":
+"semver@npm:^7.7.3":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
   bin:
@@ -8904,23 +8801,23 @@ __metadata:
   resolution: "terafoundation_kafka_connector@workspace:packages/terafoundation_kafka_connector"
   dependencies:
     "@confluentinc/kafka-javascript": "npm:~1.8.0"
-    "@terascope/core-utils": "npm:~2.2.1"
-    "@terascope/job-components": "npm:~2.2.1"
-    "@terascope/scripts": "npm:~2.2.1"
+    "@terascope/core-utils": "npm:~2.2.2"
+    "@terascope/job-components": "npm:~2.2.2"
+    "@terascope/scripts": "npm:~2.2.2"
     "@types/convict": "npm:~6.1.6"
     convict: "npm:~6.2.4"
   languageName: unknown
   linkType: soft
 
-"teraslice-test-harness@npm:~2.2.1":
-  version: 2.2.1
-  resolution: "teraslice-test-harness@npm:2.2.1"
+"teraslice-test-harness@npm:~2.2.2":
+  version: 2.2.2
+  resolution: "teraslice-test-harness@npm:2.2.2"
   dependencies:
-    "@terascope/fetch-github-release": "npm:~2.2.1"
-    "@terascope/job-components": "npm:~2.2.1"
+    "@terascope/fetch-github-release": "npm:~2.2.2"
+    "@terascope/job-components": "npm:~2.2.2"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.3"
-  checksum: 10c0/b14b3865178044e01041bf426945d80d493251268f73f195a9d31024c16ed9e33855cc44c37ddd64338adb6db4d88e0772ed2655e57ad18203d2b4221e53ab22
+  checksum: 10c0/faa768f0e9a93059b4a71f04a2c5c0ba7446f7713aa58a8f0cffbc8376b0f22ab797b124e9dbd4f2f49870a78f475db093fb6131efcf6dec2b9681a2369acca4
   languageName: node
   linkType: hard
 
@@ -9167,18 +9064,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:~4.9.0":
-  version: 4.9.0
-  resolution: "typedoc-plugin-markdown@npm:4.9.0"
+"typedoc-plugin-markdown@npm:~4.10.0":
+  version: 4.10.0
+  resolution: "typedoc-plugin-markdown@npm:4.10.0"
   peerDependencies:
     typedoc: 0.28.x
-  checksum: 10c0/12040bbff7bc7e4f777d06710e39421f8ebaaf706f4b8075536453f35bc86726c5ce743de0cc9c39ee1bdfc8611b2878a4cf4c83a493e0678fc640dd71fe97fc
+  checksum: 10c0/20c7bc8ef68bd90053649ce223d02d4aceefed675c09efb1740c7791fbc37c10a1e25d14647605484a198f0695312eb21119015616d91c73fe1d63df5e4fb061
   languageName: node
   linkType: hard
 
-"typedoc@npm:~0.28.16":
-  version: 0.28.16
-  resolution: "typedoc@npm:0.28.16"
+"typedoc@npm:~0.28.17":
+  version: 0.28.17
+  resolution: "typedoc@npm:0.28.17"
   dependencies:
     "@gerrit0/mini-shiki": "npm:^3.17.0"
     lunr: "npm:^2.3.9"
@@ -9189,7 +9086,7 @@ __metadata:
     typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10c0/ae444913068088e88be6319a017a3a18f69cbd91dbb5b959fbdd0cf87d1a2a07f3a0d4ab29c957a83dd72808ff35bdd6ceec3ad1803fa412ddceffb78fa60ebb
+  checksum: 10c0/25c3f6c08748debd2549e8af2c96dcdea255297924e8e0ecc78c86aea35d69c149eb5ad0a0d333a3a69d4e41a887ce55fef0aa97236789f0e658f3ad051429e8
   languageName: node
   linkType: hard
 
@@ -9743,7 +9640,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:~18.0.0":
+"yargs@npm:^18.0.0, yargs@npm:~18.0.0":
   version: 18.0.0
   resolution: "yargs@npm:18.0.0"
   dependencies:


### PR DESCRIPTION
This PR updates the following packages:
# kafka-assets
  - dependencies
    - @terascope/core-utils from 2.2.1 to 2.2.2
    - @terascope/job-components from 2.2.1 to 2.2.2
# kafka-asset-bundle
  - devDependencies
    - @terascope/core-utils from 2.2.1 to 2.2.2
    - @terascope/job-components from 2.2.1 to 2.2.2
    - @terascope/scripts from 2.2.1 to 2.2.2
    - @types/node from 24.10.13 to 24.10.15
    - teraslice-test-harness from 2.2.1 to 2.2.2
# terafoundation_kafka_connector
  - devDependencies
    - @terascope/core-utils from 2.2.1 to 2.2.2
    - @terascope/job-components from 2.2.1 to 2.2.2
    - @terascope/scripts from 2.2.1 to 2.2.2