### PR TITLE
[tests, CI] Add e2e tests that use teraslice 

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -16,10 +16,10 @@ permissions:
 jobs:
   call-master-asset-build:
     if: github.event.pull_request.merged == true && github.base_ref == 'master'
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@main
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@asset-e2e
     secrets: inherit
 
   call-prerelease-asset-build:
     if: github.event.pull_request.merged == true && startsWith(github.base_ref, 'release/kafka-assets-v')
-    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@main
+    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@asset-e2e
     secrets: inherit

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-refresh-docker-cache-workflow:
-    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@main
+    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@asset-e2e
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -10,5 +10,5 @@ on:
       - master
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@main
+    uses: terascope/workflows/.github/workflows/asset-test.yml@asset-e2e
     secrets: inherit

--- a/.github/workflows/test-prerelease-asset.yml
+++ b/.github/workflows/test-prerelease-asset.yml
@@ -11,5 +11,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@main
+    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@asset-e2e
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@terascope/eslint-config": "~1.1.29",
         "@terascope/job-components": "~2.3.2",
         "@terascope/scripts": "~2.3.4",
+        "@terascope/types": "~2.3.1",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
         "@types/node": "~25.5.0",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
         "lint:fix": "pnpm lint --fix",
         "publish:changed": "./scripts/publish.sh",
         "setup": "pnpm install && pnpm build --force",
-        "test": "ts-scripts test asset --",
-        "test:all": "ts-scripts test",
+        "test": "ts-scripts test asset -- --testPathIgnorePatterns=test/e2e",
+        "test:all": "ts-scripts test -- --testPathIgnorePatterns=test/e2e",
         "test:debug": "ts-scripts test --debug asset --",
-        "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test -- --testPathIgnorePatterns version-sync-spec generic-asset-spec base-client-spec helpers/helpers-spec kafka_dead_letter/schema-spec kafka_reader/slicer-spec",
+        "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test -- --testPathIgnorePatterns version-sync-spec generic-asset-spec base-client-spec helpers/helpers-spec kafka_dead_letter/schema-spec kafka_reader/slicer-spec test/e2e",
         "test:e2e": "earl assets build --overwrite && ASSET_ZIP_PATH=$(ls ./build/*.zip | head -1) TEST_TERASLICE=true ts-scripts test -- --testPathPatterns=test/e2e",
         "test:watch": "ts-scripts test --watch asset --"
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "test:all": "ts-scripts test -- --testPathIgnorePatterns=test/e2e",
         "test:debug": "ts-scripts test --debug asset --",
         "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test -- --testPathIgnorePatterns 'version-sync-spec|generic-asset-spec|base-client-spec|helpers/helpers-spec|kafka_dead_letter/schema-spec|kafka_reader/slicer-spec|test/e2e'",
-        "test:e2e": "earl assets build --overwrite && ASSET_ZIP_PATH=$(ls ./build/*.zip | head -1) TEST_TERASLICE=true ts-scripts test -- --testPathPatterns=test/e2e",
+        "test:e2e": "earl assets build --overwrite && ASSET_ZIP_PATH=$(./scripts/asset-zip-path.sh) TEST_TERASLICE=true ts-scripts test -- --testPathPatterns=test/e2e",
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
@@ -50,7 +50,7 @@
         "jest-extended": "~7.0.0",
         "semver": "~7.7.4",
         "terafoundation_kafka_connector": "workspace:~",
-        "teraslice-client-js": "^2.3.2",
+        "teraslice-client-js": "~2.3.2",
         "teraslice-test-harness": "~2.4.0",
         "ts-jest": "~29.4.6",
         "typescript": "~5.9.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "test:all": "ts-scripts test",
         "test:debug": "ts-scripts test --debug asset --",
         "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test -- --testPathIgnorePatterns version-sync-spec generic-asset-spec base-client-spec helpers/helpers-spec kafka_dead_letter/schema-spec kafka_reader/slicer-spec",
+        "test:e2e": "earl assets build --overwrite && ASSET_ZIP_PATH=$(ls ./build/*.zip | head -1) TEST_TERASLICE=true ts-scripts test -- --testPathPatterns=test/e2e",
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
@@ -49,6 +50,7 @@
         "jest-extended": "~7.0.0",
         "semver": "~7.7.4",
         "terafoundation_kafka_connector": "workspace:~",
+        "teraslice-client-js": "^2.3.2",
         "teraslice-test-harness": "~2.4.0",
         "ts-jest": "~29.4.6",
         "typescript": "~5.9.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "test": "ts-scripts test asset -- --testPathIgnorePatterns=test/e2e",
         "test:all": "ts-scripts test -- --testPathIgnorePatterns=test/e2e",
         "test:debug": "ts-scripts test --debug asset --",
-        "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test -- --testPathIgnorePatterns version-sync-spec generic-asset-spec base-client-spec helpers/helpers-spec kafka_dead_letter/schema-spec kafka_reader/slicer-spec test/e2e",
+        "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test -- --testPathIgnorePatterns 'version-sync-spec|generic-asset-spec|base-client-spec|helpers/helpers-spec|kafka_dead_letter/schema-spec|kafka_reader/slicer-spec|test/e2e'",
         "test:e2e": "earl assets build --overwrite && ASSET_ZIP_PATH=$(ls ./build/*.zip | head -1) TEST_TERASLICE=true ts-scripts test -- --testPathPatterns=test/e2e",
         "test:watch": "ts-scripts test --watch asset --"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
         specifier: workspace:~
         version: link:packages/terafoundation_kafka_connector
       teraslice-client-js:
-        specifier: ^2.3.2
+        specifier: ~2.3.2
         version: 2.3.2
       teraslice-test-harness:
         specifier: ~2.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ~2.3.2
         version: 2.3.2
       '@terascope/scripts':
-        specifier: ~2.3.4
-        version: 2.3.4(typescript@5.9.3)
+        specifier: file:./terascope-scripts-2.3.5.tgz
+        version: file:terascope-scripts-2.3.5.tgz(typescript@5.9.3)
       '@types/fs-extra':
         specifier: ~11.0.4
         version: 11.0.4
@@ -56,6 +56,9 @@ importers:
       terafoundation_kafka_connector:
         specifier: workspace:~
         version: link:packages/terafoundation_kafka_connector
+      teraslice-client-js:
+        specifier: ^2.3.2
+        version: 2.3.2
       teraslice-test-harness:
         specifier: ~2.4.0
         version: 2.4.0
@@ -94,8 +97,8 @@ importers:
         specifier: ~2.3.2
         version: 2.3.2
       '@terascope/scripts':
-        specifier: ~2.3.4
-        version: 2.3.4(typescript@5.9.3)
+        specifier: file:../../terascope-scripts-2.3.5.tgz
+        version: file:terascope-scripts-2.3.5.tgz(typescript@5.9.3)
       '@types/convict':
         specifier: ~6.1.6
         version: 6.1.6
@@ -606,8 +609,9 @@ packages:
     resolution: {integrity: sha512-pff6Rk8O2nnURWS0b3ra5XHKM61BwZjw5BX48VIUfXbsMKtG3y++sHypiqZ9aDiaMIrxt2eSJXsUJzJHCMpSiQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/scripts@2.3.4':
-    resolution: {integrity: sha512-x5g+d0+WzhBAGqs+ivqNhz1/62BW6Vts4lq6doJmbOO9MfO0jQKw7r49eJ0RQt5ERF/6Ul7rKNLm/3sfdcF7Bg==}
+  '@terascope/scripts@file:terascope-scripts-2.3.5.tgz':
+    resolution: {integrity: sha512-OIURLwn+Z88k16hOy9LXqADTR1w54lJkylhrgPTQUS2WF6lBp0AunXXbd3hBmo+QVg9kMGXFRf3xQ7sq+soOTw==, tarball: file:terascope-scripts-2.3.5.tgz}
+    version: 2.3.5
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
     hasBin: true
     peerDependencies:
@@ -1002,6 +1006,10 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -3224,6 +3232,10 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
+  teraslice-client-js@2.3.2:
+    resolution: {integrity: sha512-E0M8ZK6AiGgOqrI0N5tuHW/VrLpblFRlEJtJbQROLRuLhHg/gY2KOlrMOCualSTzxPMoLklBedK7tNuRaWLzlw==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
+
   teraslice-test-harness@2.4.0:
     resolution: {integrity: sha512-QLDQRgHtbT+N5efkzoLBqngbXofrc2is9llwWqCpxw9n0Ps0z0v+C/3B5uYFfEAxJb5ah6cb2XTgR65aSDuXlA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
@@ -4270,7 +4282,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/scripts@2.3.4(typescript@5.9.3)':
+  '@terascope/scripts@file:terascope-scripts-2.3.5.tgz(typescript@5.9.3)':
     dependencies:
       '@kubernetes/client-node': 1.4.0
       '@terascope/core-utils': 2.3.2
@@ -4737,6 +4749,8 @@ snapshots:
   async-function@1.0.0: {}
 
   asynckit@0.4.0: {}
+
+  auto-bind@5.0.1: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -7351,6 +7365,15 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  teraslice-client-js@2.3.2:
+    dependencies:
+      '@terascope/core-utils': 2.3.2
+      '@terascope/types': 2.3.1
+      auto-bind: 5.0.1
+      got: 14.6.6
+    transitivePeerDependencies:
+      - supports-color
 
   teraslice-test-harness@2.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ~2.3.2
         version: 2.3.2
       '@terascope/scripts':
-        specifier: file:./terascope-scripts-2.3.5.tgz
-        version: file:terascope-scripts-2.3.5.tgz(typescript@5.9.3)
+        specifier: ~2.3.4
+        version: 2.3.6(typescript@5.9.3)
       '@types/fs-extra':
         specifier: ~11.0.4
         version: 11.0.4
@@ -97,8 +97,8 @@ importers:
         specifier: ~2.3.2
         version: 2.3.2
       '@terascope/scripts':
-        specifier: file:../../terascope-scripts-2.3.5.tgz
-        version: file:terascope-scripts-2.3.5.tgz(typescript@5.9.3)
+        specifier: ~2.3.4
+        version: 2.3.6(typescript@5.9.3)
       '@types/convict':
         specifier: ~6.1.6
         version: 6.1.6
@@ -609,9 +609,8 @@ packages:
     resolution: {integrity: sha512-pff6Rk8O2nnURWS0b3ra5XHKM61BwZjw5BX48VIUfXbsMKtG3y++sHypiqZ9aDiaMIrxt2eSJXsUJzJHCMpSiQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/scripts@file:terascope-scripts-2.3.5.tgz':
-    resolution: {integrity: sha512-OIURLwn+Z88k16hOy9LXqADTR1w54lJkylhrgPTQUS2WF6lBp0AunXXbd3hBmo+QVg9kMGXFRf3xQ7sq+soOTw==, tarball: file:terascope-scripts-2.3.5.tgz}
-    version: 2.3.5
+  '@terascope/scripts@2.3.6':
+    resolution: {integrity: sha512-FN3GUTVqlXjQtBG9lVlIkVP4onagfRkKBIRwZzIE709NP+dkuhiOTDgsi7PNvZ16/Fi+3eRTyGlpznlPwLPRvg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
     hasBin: true
     peerDependencies:
@@ -4282,7 +4281,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/scripts@file:terascope-scripts-2.3.5.tgz(typescript@5.9.3)':
+  '@terascope/scripts@2.3.6(typescript@5.9.3)':
     dependencies:
       '@kubernetes/client-node': 1.4.0
       '@terascope/core-utils': 2.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@terascope/scripts':
         specifier: ~2.3.4
         version: 2.3.6(typescript@5.9.3)
+      '@terascope/types':
+        specifier: ~2.3.1
+        version: 2.3.1
       '@types/fs-extra':
         specifier: ~11.0.4
         version: 11.0.4

--- a/scripts/asset-zip-path.sh
+++ b/scripts/asset-zip-path.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_VERSION=$(node -p "require('${SCRIPT_DIR}/../package.json').version")
+NODE_VERSION=$(node -p "process.versions.node.split('.')[0]")
+
+echo "./build/kafka-v${PACKAGE_VERSION}-node-${NODE_VERSION}-bundle.zip"

--- a/test/e2e/config.ts
+++ b/test/e2e/config.ts
@@ -3,27 +3,24 @@ import { SchemaValidator } from '@terascope/core-utils';
 type E2EConfig = {
     TERASLICE_HOST: string;
     ASSET_ZIP_PATH: string;
-    KAFKA_BROKERS: string;
+    KAFKA_BROKER: string;
 };
 
 const schema = {
     TERASLICE_HOST: {
         default: null,
-        format: String,
-        env: 'TERASLICE_HOST'
+        format: 'required_string'
     },
     ASSET_ZIP_PATH: {
         default: null,
-        format: String,
-        env: 'ASSET_ZIP_PATH'
+        format: 'required_string'
     },
-    KAFKA_BROKERS: {
-        default: 'localhost:9092',
-        format: 'optional_string' as const,
-        env: 'KAFKA_BROKERS'
+    KAFKA_BROKER: {
+        default: null,
+        format: 'required_string'
     }
 };
 
 const validator = new SchemaValidator<E2EConfig>(schema, 'e2e-config');
 
-export default validator.validate({});
+export default validator.validate(process.env);

--- a/test/e2e/config.ts
+++ b/test/e2e/config.ts
@@ -1,12 +1,14 @@
 import { SchemaValidator } from '@terascope/core-utils';
+import { Terafoundation } from '@terascope/types';
 
 type E2EConfig = {
     TERASLICE_HOST: string;
     ASSET_ZIP_PATH: string;
     KAFKA_BROKER: string;
+    TEST_TERASLICE: boolean;
 };
 
-const schema = {
+const schema: Terafoundation.Schema<any> = {
     TERASLICE_HOST: {
         default: null,
         format: 'required_string'
@@ -18,9 +20,13 @@ const schema = {
     KAFKA_BROKER: {
         default: null,
         format: 'required_string'
-    }
+    },
+    TEST_TERASLICE: {
+        default: false,
+        format: Boolean,
+    },
 };
 
-const validator = new SchemaValidator<E2EConfig>(schema, 'e2e-config');
+const validator = new SchemaValidator<E2EConfig>(schema, 'e2e-config', undefined, 'allow');
 
 export default validator.validate(process.env);

--- a/test/e2e/config.ts
+++ b/test/e2e/config.ts
@@ -1,0 +1,29 @@
+import { SchemaValidator } from '@terascope/core-utils';
+
+type E2EConfig = {
+    TERASLICE_HOST: string;
+    ASSET_ZIP_PATH: string;
+    KAFKA_BROKERS: string;
+};
+
+const schema = {
+    TERASLICE_HOST: {
+        default: null,
+        format: String,
+        env: 'TERASLICE_HOST'
+    },
+    ASSET_ZIP_PATH: {
+        default: null,
+        format: String,
+        env: 'ASSET_ZIP_PATH'
+    },
+    KAFKA_BROKERS: {
+        default: 'localhost:9092',
+        format: 'optional_string' as const,
+        env: 'KAFKA_BROKERS'
+    }
+};
+
+const validator = new SchemaValidator<E2EConfig>(schema, 'e2e-config');
+
+export default validator.validate({});

--- a/test/e2e/e2e-spec.ts
+++ b/test/e2e/e2e-spec.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 import 'jest-extended';
 import fs from 'node:fs';
-import TerasliceClient from 'teraslice-client-js';
+import { TerasliceClient, Job } from 'teraslice-client-js';
 import { v4 as uuidv4 } from 'uuid';
 import { loadData, readData } from '../helpers/kafka-data.js';
 import KafkaAdmin from '../helpers/kafka-admin.js';
@@ -39,7 +39,7 @@ describe('Kafka Assets e2e', () => {
         const consumerGroup = `e2e-group-${uuidv4()}`;
 
         const admin = new KafkaAdmin();
-        let ex: any;
+        let job: Job;
         let exampleData: Record<string, any>[];
 
         beforeAll(async () => {
@@ -52,9 +52,9 @@ describe('Kafka Assets e2e', () => {
         afterAll(async () => {
             admin.disconnect();
 
-            if (ex) {
+            if (job) {
                 try {
-                    await ex.stop();
+                    await job.stop();
                 } catch (_err) {
                     // job may already be stopped
                 }
@@ -62,7 +62,7 @@ describe('Kafka Assets e2e', () => {
         });
 
         it('should pipe records end to end', async () => {
-            ex = await client.jobs.submit({
+            job = await client.jobs.submit({
                 name: 'e2e-kafka-pipeline',
                 lifecycle: 'persistent',
                 workers: 1,
@@ -93,7 +93,7 @@ describe('Kafka Assets e2e', () => {
                 ]
             });
 
-            await ex.waitForStatus('running');
+            await job.waitForStatus('running');
 
             // Poll until we have all expected messages (up to 6 × 10s = 60s)
             let consumed: any[] = [];
@@ -102,8 +102,7 @@ describe('Kafka Assets e2e', () => {
                 if (consumed.length >= exampleData.length) break;
             }
 
-            await ex.stop();
-            ex = null;
+            await job.stop();
 
             expect(consumed).toBeArrayOfSize(exampleData.length);
             for (let i = 0; i < exampleData.length; i++) {

--- a/test/e2e/e2e-spec.ts
+++ b/test/e2e/e2e-spec.ts
@@ -5,8 +5,7 @@ import TerasliceClient from 'teraslice-client-js';
 import { v4 as uuidv4 } from 'uuid';
 import { loadData, readData } from '../helpers/kafka-data.js';
 import KafkaAdmin from '../helpers/kafka-admin.js';
-
-// const describeE2E = process.env.TEST_TERASLICE === 'true' ? describe : describe.skip;
+import config from './config.js';
 
 describe('Kafka Assets e2e', () => {
     jest.setTimeout(120 * 1000);
@@ -14,13 +13,13 @@ describe('Kafka Assets e2e', () => {
     let client: TerasliceClient;
 
     beforeAll(async () => {
-        client = new TerasliceClient({ host: process.env.TERASLICE_HOST! });
+        client = new TerasliceClient({ host: config.TERASLICE_HOST });
     });
 
     describe('asset upload', () => {
         it('should upload the asset bundle', async () => {
             const result = await client.assets.upload(
-                fs.createReadStream(process.env.ASSET_ZIP_PATH!)
+                fs.createReadStream(config.ASSET_ZIP_PATH)
             );
 
             expect(result.asset_id).toBeDefined();

--- a/test/e2e/e2e-spec.ts
+++ b/test/e2e/e2e-spec.ts
@@ -1,0 +1,115 @@
+import { jest } from '@jest/globals';
+import 'jest-extended';
+import fs from 'node:fs';
+import TerasliceClient from 'teraslice-client-js';
+import { v4 as uuidv4 } from 'uuid';
+import { loadData, readData } from '../helpers/kafka-data.js';
+import KafkaAdmin from '../helpers/kafka-admin.js';
+
+// const describeE2E = process.env.TEST_TERASLICE === 'true' ? describe : describe.skip;
+
+describe('Kafka Assets e2e', () => {
+    jest.setTimeout(120 * 1000);
+
+    let client: TerasliceClient;
+
+    beforeAll(async () => {
+        client = new TerasliceClient({ host: process.env.TERASLICE_HOST! });
+    });
+
+    describe('asset upload', () => {
+        it('should upload the asset bundle', async () => {
+            const result = await client.assets.upload(
+                fs.createReadStream(process.env.ASSET_ZIP_PATH!)
+            );
+
+            expect(result.asset_id).toBeDefined();
+        });
+
+        it('should be discoverable on the cluster after upload', async () => {
+            const records = await client.assets.getAsset('kafka');
+
+            expect(records).not.toBeEmpty();
+            expect(records[0].name).toBe('kafka');
+        });
+    });
+
+    describe('kafka_reader → kafka_sender', () => {
+        const inputTopic = `e2e-kafka-input-${uuidv4()}`;
+        const outputTopic = `e2e-kafka-output-${uuidv4()}`;
+        const consumerGroup = `e2e-group-${uuidv4()}`;
+
+        const admin = new KafkaAdmin();
+        let ex: any;
+        let exampleData: Record<string, any>[];
+
+        beforeAll(async () => {
+            await admin.ensureTopic(inputTopic);
+            await admin.ensureTopic(outputTopic);
+
+            exampleData = await loadData(inputTopic, 'e2e-data.txt');
+        });
+
+        afterAll(async () => {
+            admin.disconnect();
+
+            if (ex) {
+                try {
+                    await ex.stop();
+                } catch (_err) {
+                    // job may already be stopped
+                }
+            }
+        });
+
+        it('should pipe records end to end', async () => {
+            ex = await client.jobs.submit({
+                name: 'e2e-kafka-pipeline',
+                lifecycle: 'persistent',
+                workers: 1,
+                assets: ['kafka'],
+                operations: [
+                    {
+                        _op: 'kafka_reader',
+                        _api_name: 'kafka_reader_api'
+                    },
+                    {
+                        _op: 'kafka_sender',
+                        _api_name: 'kafka_sender_api'
+                    }
+                ],
+                apis: [
+                    {
+                        _name: 'kafka_reader_api',
+                        topic: inputTopic,
+                        group: consumerGroup,
+                        size: 100,
+                        wait: 5000,
+                        offset_reset: 'smallest'
+                    },
+                    {
+                        _name: 'kafka_sender_api',
+                        topic: outputTopic
+                    }
+                ]
+            });
+
+            await ex.waitForStatus('running');
+
+            // Poll until we have all expected messages (up to 6 × 10s = 60s)
+            let consumed: any[] = [];
+            for (let attempt = 0; attempt < 6; attempt++) {
+                consumed = await readData(outputTopic, exampleData.length);
+                if (consumed.length >= exampleData.length) break;
+            }
+
+            await ex.stop();
+            ex = null;
+
+            expect(consumed).toBeArrayOfSize(exampleData.length);
+            for (let i = 0; i < exampleData.length; i++) {
+                expect(consumed[i]).toEqual(exampleData[i]);
+            }
+        });
+    });
+});

--- a/test/fixtures/e2e-data.txt
+++ b/test/fixtures/e2e-data.txt
@@ -1,0 +1,10 @@
+{"id":"a1b2c3d4-0001-4000-8000-000000000001","name":"Alice Martin","ip":"10.0.0.1","url":"http://example.com/1","created":"Mon Jan 01 2024 00:00:01 GMT+0000 (UTC)"}
+{"id":"a1b2c3d4-0002-4000-8000-000000000002","name":"Bob Johnson","ip":"10.0.0.2","url":"http://example.com/2","created":"Mon Jan 01 2024 00:00:02 GMT+0000 (UTC)"}
+{"id":"a1b2c3d4-0003-4000-8000-000000000003","name":"Carol Williams","ip":"10.0.0.3","url":"http://example.com/3","created":"Mon Jan 01 2024 00:00:03 GMT+0000 (UTC)"}
+{"id":"a1b2c3d4-0004-4000-8000-000000000004","name":"David Brown","ip":"10.0.0.4","url":"http://example.com/4","created":"Mon Jan 01 2024 00:00:04 GMT+0000 (UTC)"}
+{"id":"a1b2c3d4-0005-4000-8000-000000000005","name":"Eve Davis","ip":"10.0.0.5","url":"http://example.com/5","created":"Mon Jan 01 2024 00:00:05 GMT+0000 (UTC)"}
+{"id":"a1b2c3d4-0006-4000-8000-000000000006","name":"Frank Miller","ip":"10.0.0.6","url":"http://example.com/6","created":"Mon Jan 01 2024 00:00:06 GMT+0000 (UTC)"}
+{"id":"a1b2c3d4-0007-4000-8000-000000000007","name":"Grace Wilson","ip":"10.0.0.7","url":"http://example.com/7","created":"Mon Jan 01 2024 00:00:07 GMT+0000 (UTC)"}
+{"id":"a1b2c3d4-0008-4000-8000-000000000008","name":"Henry Moore","ip":"10.0.0.8","url":"http://example.com/8","created":"Mon Jan 01 2024 00:00:08 GMT+0000 (UTC)"}
+{"id":"a1b2c3d4-0009-4000-8000-000000000009","name":"Iris Taylor","ip":"10.0.0.9","url":"http://example.com/9","created":"Mon Jan 01 2024 00:00:09 GMT+0000 (UTC)"}
+{"id":"a1b2c3d4-0010-4000-8000-000000000010","name":"Jack Anderson","ip":"10.0.0.10","url":"http://example.com/10","created":"Mon Jan 01 2024 00:00:10 GMT+0000 (UTC)"}


### PR DESCRIPTION
This PR makes the following changes:

- Adds `teraslice-client-js` as a devDependency 
- Adds simple `kafka-sender` and `kafka-reader` e2e test job 
  - This these tests will run against the latest teraslice image published to ghcr