### PR TITLE
[kafka-sender] improve delivery-report logging

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "minimum_teraslice_version": "3.3.3"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/asset/src/_kafka_clients/producer-client.ts
+++ b/asset/src/_kafka_clients/producer-client.ts
@@ -122,6 +122,7 @@ export default class ProducerClient extends BaseClient<Producer> {
         }
 
         try {
+            // If only_error is true or there are no messages we will not gather batch stats
             if (this.deliveryReportConfig && !this.deliveryReportConfig?.only_error && total > 0) {
                 this.deliveryReportStats[batchNumber] = {
                     received: 0,
@@ -142,7 +143,7 @@ export default class ProducerClient extends BaseClient<Producer> {
                  */
                 waitForAllReceived = new Promise((resolve, reject) => {
                     const timer = setTimeout(() => {
-                        reject(new Error(`Timed out waiting for delivery reports for batch ${batchNumber} after ${waitTimeout}ms`));
+                        reject(new Error(`Delivery-report: waitTimeout exceeded for batch ${batchNumber}: ${waitTimeout}ms.`));
                     }, waitTimeout);
 
                     allReceivedOff = this._once(`delivery-report:batch:${batchNumber}`, (err, args) => {
@@ -150,10 +151,10 @@ export default class ProducerClient extends BaseClient<Producer> {
                         const [report, stats] = args;
                         if (err) {
                             const { msgNumber } = report.opaque;
-                            reject(new Error(`Delivery report error received for batchNumber ${batchNumber}, msgNumber ${msgNumber}, err ${err}`));
+                            reject(new Error(`Delivery-report: error received for batchNumber ${batchNumber}, msgNumber ${msgNumber}, err ${err}`));
                         } else {
                             this._logger.debug(
-                                `All ${report?.opaque?.msgNumber} delivery reports received for batchNumber ${batchNumber}. Stats: ${JSON.stringify(stats)}`
+                                `Delivery-report: all ${report?.opaque?.msgNumber} reports received for batchNumber ${batchNumber}. Stats: ${JSON.stringify(stats)}`
                             );
                             resolve();
                         }
@@ -296,6 +297,7 @@ export default class ProducerClient extends BaseClient<Producer> {
                 const { batchNumber, msgNumber } = report.opaque as DeliveryReportOpaque;
                 const currBatchStats: DeliveryReportBatchStats | undefined
                     = this.deliveryReportStats[batchNumber];
+                const errLogMsg = `Delivery-report: error received for batchNumber ${batchNumber}, msgNumber ${msgNumber}. Report: ${JSON.stringify(report)}`;
 
                 if (currBatchStats && this.deliveryReportConfig) {
                     const { on_error, wait } = this.deliveryReportConfig;
@@ -308,19 +310,20 @@ export default class ProducerClient extends BaseClient<Producer> {
                         if (on_error !== 'ignore') {
                             on_error === 'throw'
                                 ? this._events.emit(`delivery-report:batch:${batchNumber}`, err, report, currBatchStats)
-                                : this._logger.error(err, `failed delivery for message ${msgNumber} of batch ${batchNumber}. Report: ${report}`);
+                                : this._logger.error(err, errLogMsg);
                         }
                     }
 
                     if (currBatchStats.received === currBatchStats.expected) {
                         wait
                             ? this._events.emit(`delivery-report:batch:${batchNumber}`, report, currBatchStats)
-                            : this._logger.debug(`All ${currBatchStats.received} delivery reports received for batch ${batchNumber}: ${currBatchStats}`);
+                            : this._logger.debug(`Delivery-report: all ${currBatchStats.received} reports received for batch ${batchNumber}: ${JSON.stringify(currBatchStats)}`);
                         delete this.deliveryReportStats[batchNumber];
                     }
                 } else {
+                    // currBatchStats will not exist when only_error is true. on_error must be log.
                     if (err) {
-                        this._logger.error(err, `failed delivery for message ${msgNumber} of batch ${batchNumber}. Report: ${report}`);
+                        this._logger.error(err, errLogMsg);
                     }
                 }
             });

--- a/asset/src/kafka_sender_api/schema.ts
+++ b/asset/src/kafka_sender_api/schema.ts
@@ -145,6 +145,9 @@ export default class Schema extends BaseSchema<Record<string, any>> {
                 throw new Error('If parameter delivery_report.only_error is set then `delivery.report.only.error`'
                     + ' can not be set on rdkafka_options.');
             }
+            if (report.only_error === true && report.on_error !== 'log') {
+                throw new Error('If parameter delivery_report.only_error is true then delivery_report.on_error must be `log`');
+            }
             if ((rd_opts.dr_cb === false && rd_opts.dr_msg_cb !== true)
                 || (rd_opts.dr_msg_cb === false && rd_opts.dr_cb !== true)
             ) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",
@@ -29,8 +29,8 @@
         "test": "ts-scripts test asset -- --testPathIgnorePatterns=test/e2e",
         "test:all": "ts-scripts test -- --testPathIgnorePatterns=test/e2e",
         "test:debug": "ts-scripts test --debug asset --",
-        "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test -- --testPathIgnorePatterns 'version-sync-spec|generic-asset-spec|base-client-spec|helpers/helpers-spec|kafka_dead_letter/schema-spec|kafka_reader/slicer-spec|test/e2e'",
         "test:e2e": "earl assets build --overwrite && ASSET_ZIP_PATH=$(./scripts/asset-zip-path.sh) TEST_TERASLICE=true ts-scripts test -- --testPathPatterns=test/e2e",
+        "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test -- --testPathIgnorePatterns 'version-sync-spec|generic-asset-spec|base-client-spec|helpers/helpers-spec|kafka_dead_letter/schema-spec|kafka_reader/slicer-spec|test/e2e'",
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -18,8 +18,8 @@
         "build:watch": "pnpm build --watch",
         "prepare": "pnpm build",
         "test": "ts-scripts test . --",
-        "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test . -- --testPathIgnorePatterns helpers-spec",
         "test:debug": "ts-scripts test --debug . --",
+        "test:encrypted": "ENCRYPT_KAFKA=true ts-scripts test . -- --testPathIgnorePatterns helpers-spec",
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {

--- a/test/kafka_sender_api/sender-spec.ts
+++ b/test/kafka_sender_api/sender-spec.ts
@@ -542,7 +542,7 @@ describe('KafkaRouteSender', () => {
             } catch (err) {
                 expect(err).toHaveProperty(
                     'message',
-                    'Delivery report error received for batchNumber 1, msgNumber 2, err Error: Local: Message timed out'
+                    'Delivery-report: error received for batchNumber 1, msgNumber 2, err Error: Local: Message timed out'
                 );
             } finally {
                 execSync(kafkaConfigsCmd
@@ -588,7 +588,7 @@ describe('KafkaRouteSender', () => {
 
             expect(loggerErrorSpy).not.toHaveBeenCalled();
             expect(loggerDebugSpy).toHaveBeenLastCalledWith(
-                'All 2 delivery reports received for batchNumber 1. Stats: {"received":2,"errors":1,"expected":2}'
+                'Delivery-report: all 2 reports received for batchNumber 1. Stats: {"received":2,"errors":1,"expected":2}'
             );
 
             execSync(kafkaConfigsCmd
@@ -622,10 +622,10 @@ describe('KafkaRouteSender', () => {
             await pDelay(500);
 
             expect(loggerDebugSpy).toHaveBeenCalledWith(
-                expect.stringContaining('All 2 delivery reports received for batch 1')
+                expect.stringContaining('Delivery-report: all 2 reports received for batch 1')
             );
             expect(loggerDebugSpy).toHaveBeenCalledWith(
-                expect.stringContaining('All 2 delivery reports received for batch 2')
+                expect.stringContaining('Delivery-report: all 2 reports received for batch 2')
             );
             expect(sender.producer.deliveryReportStats).toEqual({});
         });
@@ -653,12 +653,12 @@ describe('KafkaRouteSender', () => {
 
             await sender.send(data);
             expect(loggerDebugSpy).not.toHaveBeenCalledWith(
-                expect.stringContaining('All 2 delivery reports received for batch 1')
+                expect.stringContaining('Delivery-report: all 2 reports received for batch 1')
             );
 
             await sender.send(data);
             expect(loggerDebugSpy).not.toHaveBeenCalledWith(
-                expect.stringContaining('All 2 delivery reports received for batch 2')
+                expect.stringContaining('Delivery-report: all 2 reports received for batch 2')
             );
         });
 
@@ -687,12 +687,12 @@ describe('KafkaRouteSender', () => {
             await sender.send(data);
 
             expect(loggerDebugSpy).toHaveBeenCalledWith(
-                expect.stringContaining('All 2 delivery reports received for batchNumber 1')
+                expect.stringContaining('Delivery-report: all 2 reports received for batchNumber 1')
             );
 
             await sender.send(data);
             expect(loggerDebugSpy).toHaveBeenCalledWith(
-                expect.stringContaining('All 2 delivery reports received for batchNumber 2')
+                expect.stringContaining('Delivery-report: all 2 reports received for batchNumber 2')
             );
             expect(sender.producer.deliveryReportStats).toEqual({});
         });
@@ -736,7 +736,7 @@ describe('KafkaRouteSender', () => {
 
                 expect(loggerErrorSpy).toHaveBeenCalled();
                 expect(loggerDebugSpy).toHaveBeenCalledWith(
-                    expect.stringContaining('All 2 delivery reports received for batchNumber 1')
+                    expect.stringContaining('Delivery-report: all 2 reports received for batchNumber 1')
                 );
             } finally {
                 execSync(kafkaConfigsCmd
@@ -779,7 +779,7 @@ describe('KafkaRouteSender', () => {
 
             try {
                 await expect(sender.send(data)).rejects.toThrow(
-                    'Timed out waiting for delivery reports for batch 1 after 1ms'
+                    /^Delivery-report: waitTimeout exceeded for batch 1:/
                 );
             } finally {
                 execSync(kafkaConfigsCmd


### PR DESCRIPTION
This PR makes the following changes:
- Standardize all delivery-report log and error messages with a `Delivery-report:` prefix for easier filtering/searching
- Use JSON.stringify on report and stats objects in log messages so they render as readable JSON instead of [object Object]
- Add a validation rule: when delivery_report.only_error is true, on_error must be log (throw is incompatible and ignore makes no sense)