### PR TITLE
Bump @confluentinc/kafka-javascript from 1.8.2 to 1.9.0

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "6.4.0",
+    "version": "6.5.0",
     "minimum_teraslice_version": "3.3.3"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "6.4.0",
+    "version": "6.5.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "6.4.0",
+    "version": "6.5.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@confluentinc/kafka-javascript": "~1.8.2"
+        "@confluentinc/kafka-javascript": "~1.9.0"
     },
     "devDependencies": {
         "@terascope/core-utils": "~2.5.0",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation_kafka_connector",
     "displayName": "Terafoundation Kafka Connector",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "homepage": "https://github.com/terascope/kafka-assets",
     "repository": "git@github.com:terascope/kafka-assets.git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
   packages/terafoundation_kafka_connector:
     dependencies:
       '@confluentinc/kafka-javascript':
-        specifier: ~1.8.2
-        version: 1.8.2
+        specifier: ~1.9.0
+        version: 1.9.0
     devDependencies:
       '@terascope/core-utils':
         specifier: ~2.5.0
@@ -280,8 +280,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@confluentinc/kafka-javascript@1.8.2':
-    resolution: {integrity: sha512-sH607B4S00IO8omtpnUlcHeHsZ7hR2C441E4erZyFb+yXNVTl++8+BjIfIcflzW07iGHE5r5McD3oO3vxHi+ww==}
+  '@confluentinc/kafka-javascript@1.9.0':
+    resolution: {integrity: sha512-bIH0IEkpgTAiU7h+MBg7aDhS8+hxVVO5LA3XdlP28aNNIWauI31z50Y5LWjkwbWbH/1i2UBE8H5qvA7gLcttWg==}
     engines: {node: '>=18.0.0'}
 
   '@emnapi/core@1.9.1':
@@ -2595,6 +2595,9 @@ packages:
   nan@2.25.0:
     resolution: {integrity: sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==}
 
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
+
   nanoid@5.1.7:
     resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
     engines: {node: ^18 || >=20}
@@ -3231,8 +3234,8 @@ packages:
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
-  tar@7.5.11:
-    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
 
   tdigest@0.1.2:
@@ -3755,11 +3758,11 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@confluentinc/kafka-javascript@1.8.2':
+  '@confluentinc/kafka-javascript@1.9.0':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       bindings: 1.5.0
-      nan: 2.25.0
+      nan: 2.26.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -4135,7 +4138,7 @@ snapshots:
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.7.4
-      tar: 7.5.11
+      tar: 7.5.13
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6672,7 +6675,10 @@ snapshots:
       rimraf: 2.4.5
     optional: true
 
-  nan@2.25.0: {}
+  nan@2.25.0:
+    optional: true
+
+  nan@2.26.2: {}
 
   nanoid@5.1.7: {}
 
@@ -7363,7 +7369,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.11:
+  tar@7.5.13:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
This PR updates the following packages:
# kafka-asset-bundle from 6.4.0 to 6.5.0
  - devDependencies
    - terafoundation_kafka_connector from 2.1.1 to 2.2.0
# terafoundation_kafka_connector from 2.1.1 to 2.2.0
  - dependencies
    - @confluentinc/kafka-javascript  from [1.8.2](https://github.com/confluentinc/confluent-kafka-javascript/releases/tag/v1.8.2) to [1.9.0](https://github.com/confluentinc/confluent-kafka-javascript/releases/tag/v1.9.0)
      - this version bumps `librdkafka` from [2.13.2](https://github.com/confluentinc/librdkafka/releases/tag/v2.13.2) to [2.14.0](https://github.com/confluentinc/librdkafka/releases/tag/v2.14.0)