### PR TITLE
bundled dependency updates for 04-20-2026

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -17,8 +17,8 @@
         "test": "pnpm -C ../ test"
     },
     "dependencies": {
-        "@terascope/core-utils": "~2.5.0",
-        "@terascope/job-components": "~2.5.0",
+        "@terascope/core-utils": "~2.5.1",
+        "@terascope/job-components": "~2.6.0",
         "@terascope/types": "~2.5.0"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     },
     "devDependencies": {
         "@jest/globals": "^30.3.0",
-        "@terascope/core-utils": "~2.5.0",
+        "@terascope/core-utils": "~2.5.1",
         "@terascope/eslint-config": "~1.1.29",
-        "@terascope/job-components": "~2.5.0",
-        "@terascope/scripts": "~2.6.0",
+        "@terascope/job-components": "~2.6.0",
+        "@terascope/scripts": "~2.6.1",
         "@terascope/types": "~2.5.0",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
@@ -51,11 +51,11 @@
         "jest-extended": "~7.0.0",
         "semver": "~7.7.4",
         "terafoundation_kafka_connector": "workspace:~",
-        "teraslice-client-js": "~2.5.0",
-        "teraslice-test-harness": "~2.6.0",
+        "teraslice-client-js": "~2.5.1",
+        "teraslice-test-harness": "~2.7.0",
         "ts-jest": "~29.4.9",
         "typescript": "~5.9.3",
-        "uuid": "~13.0.0"
+        "uuid": "~14.0.0"
     },
     "packageManager": "pnpm@10.25.0",
     "engines": {

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -26,9 +26,9 @@
         "@confluentinc/kafka-javascript": "~1.9.0"
     },
     "devDependencies": {
-        "@terascope/core-utils": "~2.5.0",
-        "@terascope/job-components": "~2.5.0",
-        "@terascope/scripts": "~2.6.0",
+        "@terascope/core-utils": "~2.5.1",
+        "@terascope/job-components": "~2.6.0",
+        "@terascope/scripts": "~2.6.1",
         "@types/convict": "~6.1.6",
         "convict": "~6.2.5"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,17 +12,17 @@ importers:
         specifier: ^30.3.0
         version: 30.3.0
       '@terascope/core-utils':
-        specifier: ~2.5.0
-        version: 2.5.0
+        specifier: ~2.5.1
+        version: 2.5.1
       '@terascope/eslint-config':
         specifier: ~1.1.29
         version: 1.1.30(jest@30.3.0(@types/node@25.6.0))
       '@terascope/job-components':
-        specifier: ~2.5.0
-        version: 2.5.0
-      '@terascope/scripts':
         specifier: ~2.6.0
-        version: 2.6.0(typescript@5.9.3)
+        version: 2.6.0
+      '@terascope/scripts':
+        specifier: ~2.6.1
+        version: 2.6.1(typescript@5.9.3)
       '@terascope/types':
         specifier: ~2.5.0
         version: 2.5.0
@@ -60,11 +60,11 @@ importers:
         specifier: workspace:~
         version: link:packages/terafoundation_kafka_connector
       teraslice-client-js:
-        specifier: ~2.5.0
-        version: 2.5.0
+        specifier: ~2.5.1
+        version: 2.5.1
       teraslice-test-harness:
-        specifier: ~2.6.0
-        version: 2.6.0
+        specifier: ~2.7.0
+        version: 2.7.0
       ts-jest:
         specifier: ~29.4.9
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0))(typescript@5.9.3)
@@ -72,17 +72,17 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       uuid:
-        specifier: ~13.0.0
-        version: 13.0.0
+        specifier: ~14.0.0
+        version: 14.0.0
 
   asset:
     dependencies:
       '@terascope/core-utils':
-        specifier: ~2.5.0
-        version: 2.5.0
+        specifier: ~2.5.1
+        version: 2.5.1
       '@terascope/job-components':
-        specifier: ~2.5.0
-        version: 2.5.0
+        specifier: ~2.6.0
+        version: 2.6.0
       '@terascope/types':
         specifier: ~2.5.0
         version: 2.5.0
@@ -94,14 +94,14 @@ importers:
         version: 1.9.0
     devDependencies:
       '@terascope/core-utils':
-        specifier: ~2.5.0
-        version: 2.5.0
+        specifier: ~2.5.1
+        version: 2.5.1
       '@terascope/job-components':
-        specifier: ~2.5.0
-        version: 2.5.0
-      '@terascope/scripts':
         specifier: ~2.6.0
-        version: 2.6.0(typescript@5.9.3)
+        version: 2.6.0
+      '@terascope/scripts':
+        specifier: ~2.6.1
+        version: 2.6.1(typescript@5.9.3)
       '@types/convict':
         specifier: ~6.1.6
         version: 6.1.6
@@ -595,8 +595,8 @@ packages:
     peerDependencies:
       eslint: '>=9.0.0'
 
-  '@terascope/core-utils@2.5.0':
-    resolution: {integrity: sha512-f/MrKk/W0R/PsjxSnRg/SFcgifvQz1xEeOXc5zVNyutzf4qYj3W+Eijnlvlre5bTu+2aCF7dwReuvO1yRcyg9A==}
+  '@terascope/core-utils@2.5.1':
+    resolution: {integrity: sha512-0Qcwr9yIF/YndlH+T6tcFIz8MrDT0QvkLcrjnObMKEU1iQCtd0qZXa7T4S3pi8Z/m6/cFfsrGMy2yP25R9smuA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
   '@terascope/eslint-config@1.1.30':
@@ -608,12 +608,12 @@ packages:
     engines: {node: '>=22.0.0', pnpm: '>=10.32.1'}
     hasBin: true
 
-  '@terascope/job-components@2.5.0':
-    resolution: {integrity: sha512-7f/3DHlN+7szPvEfrMY1rU1BPXAe2agOXcELi2BcEq+hd7FGNk31DsAxJdHTcpAaXECQx2e3DRlTzCnWk3nrDQ==}
+  '@terascope/job-components@2.6.0':
+    resolution: {integrity: sha512-eFyHgPhwQV9IOaPGyOjss7t/jUTWTFRAjZiRksNniZ7H95aNSlOkCWHI5i7XOsINW/Jdh5Zs2LQpdcYU84f0PA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/scripts@2.6.0':
-    resolution: {integrity: sha512-WiOkTKbOOI3+QNuDtccfPDpKiipTkczVEylj8OaO5CSP2TCMGO4AsjmAkACD1JrV1S7CesiQ6O/iSu4CntYM6A==}
+  '@terascope/scripts@2.6.1':
+    resolution: {integrity: sha512-mGAR9ZqRpfrGC9hZFNXi0qNeUQuzVGjWVE+LgZl7oNPCFcj98pK57pxxiNR1k4R+PsI5+vMt+je0uD8Bu2hnpg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
     hasBin: true
     peerDependencies:
@@ -1077,8 +1077,8 @@ packages:
       bare-abort-controller:
         optional: true
 
-  bare-fs@4.7.0:
-    resolution: {integrity: sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==}
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
     engines: {bare: '>=1.16.0'}
     peerDependencies:
       bare-buffer: '*'
@@ -1107,8 +1107,8 @@ packages:
       bare-events:
         optional: true
 
-  bare-url@2.4.0:
-    resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
+  bare-url@2.4.1:
+    resolution: {integrity: sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1930,6 +1930,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
   hpagent@1.2.0:
     resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
     engines: {node: '>=14'}
@@ -2598,8 +2602,8 @@ packages:
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -2703,8 +2707,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  openid-client@6.8.2:
-    resolution: {integrity: sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==}
+  openid-client@6.8.3:
+    resolution: {integrity: sha512-AoY/NaN9esS3+xvHInFSK0g3skSfeE0uqQAKRj4rB6/GsBIvzwTUaYo9+HcqpKIaP0dP85p5W07hayKgS4GAeA==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3244,12 +3248,12 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
-  teraslice-client-js@2.5.0:
-    resolution: {integrity: sha512-PCgBUofxDEEw2LzVH48syWqDMNH8dIT2TvC0wi9GtqzKBDsxoZonVar7r+fXWVCJiS28fJaa+ffdBqtuy1R9AQ==}
+  teraslice-client-js@2.5.1:
+    resolution: {integrity: sha512-+tWWRB2w0t8rQuHi5ycB81NifkqKmlqG7jFxlymPMUSQhmhm7JmA7ESjqvx4eg1OsI31TO3hRyBB4/BQxTMrqw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  teraslice-test-harness@2.6.0:
-    resolution: {integrity: sha512-8WxeRhsU0H57hQXMEUDW0I3RFs8u/v1j+adBCrvbFxUf3aeZ/lkXbOjsZWN9nYnw+3rxcjKpA4aUiGSHHQRZjQ==}
+  teraslice-test-harness@2.7.0:
+    resolution: {integrity: sha512-/YnA+mSdDdy8mpsT22kzd5HJDxJxhGPANOFa+XAs21ZC//0VKYjh09e3TMj/+cXkq4y66mSd4a2K+i3/D4mrbA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
   test-exclude@6.0.0:
@@ -3433,6 +3437,10 @@ packages:
 
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -4115,7 +4123,7 @@ snapshots:
       js-yaml: 4.1.1
       jsonpath-plus: 10.4.0
       node-fetch: 2.7.0
-      openid-client: 6.8.2
+      openid-client: 6.8.3
       rfc4648: 1.5.4
       socks-proxy-agent: 8.0.5
       stream-buffers: 3.0.3
@@ -4229,7 +4237,7 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.4
 
-  '@terascope/core-utils@2.5.0':
+  '@terascope/core-utils@2.5.1':
     dependencies:
       '@terascope/types': 2.5.0
       awesome-phonenumber: 7.8.0
@@ -4287,9 +4295,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/job-components@2.5.0':
+  '@terascope/job-components@2.6.0':
     dependencies:
-      '@terascope/core-utils': 2.5.0
+      '@terascope/core-utils': 2.5.1
       '@terascope/types': 2.5.0
       import-meta-resolve: 4.2.0
       prom-client: 15.1.3
@@ -4298,10 +4306,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/scripts@2.6.0(typescript@5.9.3)':
+  '@terascope/scripts@2.6.1(typescript@5.9.3)':
     dependencies:
       '@kubernetes/client-node': 1.4.0
-      '@terascope/core-utils': 2.5.0
+      '@terascope/core-utils': 2.5.1
       execa: 9.6.1
       fs-extra: 11.3.4
       globby: 16.2.0
@@ -4312,7 +4320,7 @@ snapshots:
       micromatch: 4.0.8
       mnemonist: 0.40.3
       ms: 2.1.3
-      nanoid: 5.1.7
+      nanoid: 5.1.9
       package-json: 10.0.1
       package-up: 5.0.0
       semver: 7.7.4
@@ -4838,12 +4846,12 @@ snapshots:
 
   bare-events@2.8.2: {}
 
-  bare-fs@4.7.0:
+  bare-fs@4.7.1:
     dependencies:
       bare-events: 2.8.2
       bare-path: 3.0.0
       bare-stream: 2.13.0(bare-events@2.8.2)
-      bare-url: 2.4.0
+      bare-url: 2.4.1
       fast-fifo: 1.3.2
     transitivePeerDependencies:
       - bare-abort-controller
@@ -4864,7 +4872,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
-  bare-url@2.4.0:
+  bare-url@2.4.1:
     dependencies:
       bare-path: 3.0.0
 
@@ -5659,7 +5667,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       mime-types: 2.1.35
 
   fs-constants@1.0.0: {}
@@ -5844,6 +5852,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -6680,7 +6692,7 @@ snapshots:
 
   nan@2.26.2: {}
 
-  nanoid@5.1.7: {}
+  nanoid@5.1.9: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -6777,7 +6789,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openid-client@6.8.2:
+  openid-client@6.8.3:
     dependencies:
       jose: 6.2.2
       oauth4webapi: 3.8.5
@@ -7341,7 +7353,7 @@ snapshots:
       pump: 3.0.4
       tar-stream: 3.1.8
     optionalDependencies:
-      bare-fs: 4.7.0
+      bare-fs: 4.7.1
       bare-path: 3.0.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -7361,7 +7373,7 @@ snapshots:
   tar-stream@3.1.8:
     dependencies:
       b4a: 1.8.0
-      bare-fs: 4.7.0
+      bare-fs: 4.7.1
       fast-fifo: 1.3.2
       streamx: 2.25.0
     transitivePeerDependencies:
@@ -7388,19 +7400,19 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  teraslice-client-js@2.5.0:
+  teraslice-client-js@2.5.1:
     dependencies:
-      '@terascope/core-utils': 2.5.0
+      '@terascope/core-utils': 2.5.1
       '@terascope/types': 2.5.0
       auto-bind: 5.0.1
       got: 14.6.6
     transitivePeerDependencies:
       - supports-color
 
-  teraslice-test-harness@2.6.0:
+  teraslice-test-harness@2.7.0:
     dependencies:
       '@terascope/fetch-github-release': 2.3.1
-      '@terascope/job-components': 2.5.0
+      '@terascope/job-components': 2.6.0
       decompress: 4.2.1
       fs-extra: 11.3.4
     transitivePeerDependencies:
@@ -7613,6 +7625,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@13.0.0: {}
+
+  uuid@14.0.0: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -1407,8 +1407,8 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@mermaid-js/parser@1.0.1':
-    resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
+  '@mermaid-js/parser@1.1.0':
+    resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -2774,9 +2774,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.2:
-    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
-    engines: {node: '>=20'}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -3029,8 +3028,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3618,6 +3617,9 @@ packages:
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -3627,8 +3629,8 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3745,8 +3747,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.13.0:
-    resolution: {integrity: sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==}
+  mermaid@11.14.0:
+    resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -6855,7 +6857,7 @@ snapshots:
       html-tags: 3.3.1
       html-webpack-plugin: 5.6.6(webpack@5.105.4)
       leven: 3.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       open: 8.4.2
       p-map: 4.0.0
       prompts: 2.4.2
@@ -6972,7 +6974,7 @@ snapshots:
       combine-promises: 1.2.0
       feed: 4.2.2
       fs-extra: 11.3.4
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       schema-dts: 1.1.5
@@ -7014,7 +7016,7 @@ snapshots:
       combine-promises: 1.2.0
       fs-extra: 11.3.4
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       schema-dts: 1.1.5
@@ -7328,7 +7330,7 @@ snapshots:
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
       infima: 0.2.0-alpha.45
-      lodash: 4.17.23
+      lodash: 4.18.1
       nprogress: 0.2.0
       postcss: 8.5.8
       prism-react-renderer: 2.4.1(react@19.2.5)
@@ -7388,7 +7390,7 @@ snapshots:
       '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/types': 3.10.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/utils-validation': 3.10.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      mermaid: 11.13.0
+      mermaid: 11.14.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -7427,7 +7429,7 @@ snapshots:
       clsx: 2.1.1
       eta: 2.2.0
       fs-extra: 11.3.4
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -7500,7 +7502,7 @@ snapshots:
       fs-extra: 11.3.4
       joi: 17.13.3
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -7525,7 +7527,7 @@ snapshots:
       gray-matter: 4.0.3
       jiti: 1.21.7
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
       prompts: 2.4.2
@@ -7759,7 +7761,7 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
-  '@mermaid-js/parser@1.0.1':
+  '@mermaid-js/parser@1.1.0':
     dependencies:
       langium: 4.2.1
 
@@ -8740,7 +8742,7 @@ snapshots:
   chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
       chevrotain: 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   chevrotain@11.1.2:
     dependencies:
@@ -9233,7 +9235,7 @@ snapshots:
   dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   dayjs@1.11.19: {}
 
@@ -9345,7 +9347,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.2:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9636,7 +9638,7 @@ snapshots:
 
   flat@5.0.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   form-data-encoder@2.1.4: {}
 
@@ -9919,7 +9921,7 @@ snapshots:
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
@@ -9976,7 +9978,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -10249,13 +10251,15 @@ snapshots:
 
   lodash-es@4.17.23: {}
 
+  lodash-es@4.18.1: {}
+
   lodash.debounce@4.0.8: {}
 
   lodash.memoize@4.1.2: {}
 
   lodash.uniq@4.5.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   longest-streak@3.1.0: {}
 
@@ -10502,11 +10506,11 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.13.0:
+  mermaid@11.14.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 1.0.1
+      '@mermaid-js/parser': 1.1.0
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
       cytoscape: 3.33.1
@@ -10516,10 +10520,10 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.19
-      dompurify: 3.3.2
+      dompurify: 3.4.0
       katex: 0.16.38
       khroma: 2.1.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
@@ -11571,7 +11575,7 @@ snapshots:
 
   pretty-error@4.0.0:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       renderkid: 3.0.0
 
   pretty-time@1.1.0: {}
@@ -11887,7 +11891,7 @@ snapshots:
       css-select: 4.3.0
       dom-converter: 0.2.0
       htmlparser2: 6.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       strip-ansi: 6.0.1
 
   repeat-string@1.6.1: {}


### PR DESCRIPTION
This PR updates the following packages:
# kafka-assets
  - dependencies
    - @terascope/core-utils from 2.5.0 to 2.5.1
    - @terascope/job-components from 2.5.0 to 2.6.0
# kafka-asset-bundle
  - devDependencies
    - @terascope/core-utils from 2.5.0 to 2.5.1
    - @terascope/job-components from 2.5.0 to 2.6.0
    - @terascope/scripts from 2.6.0 to 2.6.1
    - teraslice-client-js from 2.5.0 to 2.5.1
    - teraslice-test-harness from 2.6.0 to 2.7.0
    - uuid from 13.0.0 to 14.0.0
# terafoundation_kafka_connector
  - devDependencies
    - @terascope/core-utils from 2.5.0 to 2.5.1
    - @terascope/job-components from 2.5.0 to 2.6.0
    - @terascope/scripts from 2.6.0 to 2.6.1