### PR TITLE
[consumer-client] Switch rebalance logs to WARN level

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "6.5.2",
+    "version": "6.5.3",
     "minimum_teraslice_version": "3.3.3"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "6.5.2",
+    "version": "6.5.3",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/asset/src/_kafka_clients/consumer-client.ts
+++ b/asset/src/_kafka_clients/consumer-client.ts
@@ -465,7 +465,7 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
      * will cause it back off longer
     */
     private _startRebalance(msg: string) {
-        this._logger.trace(`starting a rebalance ${msg}`);
+        this._logger.info(`starting a rebalance ${msg}`);
 
         this._incBackOff();
         this._rebalancing = true;
@@ -485,21 +485,21 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
     private _endRebalance(msg: string) {
         if (this._rebalanceTimeout) clearTimeout(this._rebalanceTimeout);
 
-        this._logger.trace(`rebalance ended ${msg}`);
+        this._logger.info(`rebalance ended ${msg}`);
         this._rebalancing = false;
         this._events.emit('rebalance:end');
     }
 
     private _handleRebalance(err: KafkaError | undefined, assignments: TopicPartition[]) {
         if (err && err.code === ERR__ASSIGN_PARTITIONS) {
-            this._logger.debug(`got new assignments ${formatTopar(assignments)}`);
+            this._logger.info(`got new assignments ${formatTopar(assignments)}`);
             this._assignments = assignments;
             this._endRebalance('due to new assignments');
         } else if (err && err.code === ERR__REVOKE_PARTITIONS) {
-            this._logger.debug(`revoking assignments ${formatTopar(assignments)}`);
+            this._logger.info(`revoking assignments ${formatTopar(assignments)}`);
             this._startRebalance('due to revoked assignments');
         } else {
-            this._logger.debug('kafka consumer rebalance', { err, assignments });
+            this._logger.info('kafka consumer rebalance', { err, assignments });
         }
     }
 

--- a/asset/src/_kafka_clients/consumer-client.ts
+++ b/asset/src/_kafka_clients/consumer-client.ts
@@ -465,7 +465,7 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
      * will cause it back off longer
     */
     private _startRebalance(msg: string) {
-        this._logger.info(`starting a rebalance ${msg}`);
+        this._logger.debug(`starting a rebalance ${msg}`);
 
         this._incBackOff();
         this._rebalancing = true;
@@ -485,19 +485,19 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
     private _endRebalance(msg: string) {
         if (this._rebalanceTimeout) clearTimeout(this._rebalanceTimeout);
 
-        this._logger.info(`rebalance ended ${msg}`);
+        this._logger.debug(`rebalance ended ${msg}`);
         this._rebalancing = false;
         this._events.emit('rebalance:end');
     }
 
     private _handleRebalance(err: KafkaError | undefined, assignments: TopicPartition[]) {
         if (err && err.code === ERR__ASSIGN_PARTITIONS) {
-            this._logger.info(`got new assignments ${formatTopar(assignments)}`);
+            this._logger.warn(`received new partition assignments ${formatPartitions(assignments)}`);
             this._assignments = assignments;
-            this._endRebalance('due to new assignments');
+            this._endRebalance('due to new partition assignments');
         } else if (err && err.code === ERR__REVOKE_PARTITIONS) {
-            this._logger.info(`revoking assignments ${formatTopar(assignments)}`);
-            this._startRebalance('due to revoked assignments');
+            this._logger.warn(`revoking partition assignments: ${formatPartitions(assignments)}`);
+            this._startRebalance('due to revoked partition assignments');
         } else {
             this._logger.info('kafka consumer rebalance', { err, assignments });
         }
@@ -553,6 +553,10 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
         }
         throw error;
     }
+}
+
+function formatPartitions(assignments: TopicPartition[]) {
+    return `[${assignments.map((a) => a.partition).join(', ')}]`;
 }
 
 function formatTopar(input: TopicPartition[] | TopicPartition) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "6.5.2",
+    "version": "6.5.3",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",


### PR DESCRIPTION
This PR makes the following changes:

- Raises the log level of rebalance events in `consumer-client.ts` from `trace/debug` to `warn` so that rebalance activity is visible in worker logs at the default log level.
- Bump kafka-asset from `v6.5.2` to `v6.5.3`

Ref to issue #1145 