### PR TITLE
Add consumer rebalance count for prom metrics

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "6.5.3",
+    "version": "6.5.4",
     "minimum_teraslice_version": "3.3.3"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "6.5.3",
+    "version": "6.5.4",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/asset/src/_kafka_clients/consumer-client.ts
+++ b/asset/src/_kafka_clients/consumer-client.ts
@@ -36,6 +36,7 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
     /** last known assignments */
     protected _assignments: TopicPartition[] = [];
 
+    private _rebalanceCount = 0;
     private _pendingOffsets: CountPerPartition = {};
     private _rebalanceTimeout: NodeJS.Timeout | undefined;
     private rollbackOnFailure = false;
@@ -192,6 +193,13 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
     */
     async getBytesConsumed() {
         return this._bytesConsumed;
+    }
+
+    /**
+     * Get the number of times a rebalance has been triggered
+    */
+    getRebalanceCount() {
+        return this._rebalanceCount;
     }
 
     /**
@@ -467,6 +475,7 @@ export default class ConsumerClient extends BaseClient<kafka.KafkaConsumer> {
     private _startRebalance(msg: string) {
         this._logger.debug(`starting a rebalance ${msg}`);
 
+        this._rebalanceCount++;
         this._incBackOff();
         this._rebalancing = true;
         this._events.emit('rebalance:start');

--- a/asset/src/kafka_reader/fetcher.ts
+++ b/asset/src/kafka_reader/fetcher.ts
@@ -55,6 +55,21 @@ export default class KafkaFetcher extends Fetcher<KafkaReaderConfig> {
                     };
                     this.set(labels, bytesConsumed);
                 });
+            let prevRebalanceCount = 0;
+            await this.context.apis.foundation.promMetrics.addCounter(
+                'kafka_rebalance_total',
+                'Number of times the kafka consumer has triggered a rebalance',
+                ['op_name'],
+                async function collect() {
+                    const count = consumer.getRebalanceCount();
+                    const newCount = count - prevRebalanceCount;
+                    prevRebalanceCount = count;
+                    const labels = {
+                        op_name: opConfig._op,
+                        ...context.apis.foundation.promMetrics.getDefaultLabels()
+                    };
+                    if (newCount > 0) this.inc(labels, newCount);
+                });
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "6.5.3",
+    "version": "6.5.4",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",


### PR DESCRIPTION
This PR makes the following changes:

- Adds prom metric that counts number of rebalances that occur on a consumer client
- Bump kafka-asset from `v6.5.3` to `v6.5.4`

Sample:
```
# HELP teraslice_job_kafka_rebalance_total Number of times the kafka consumer has triggered a rebalance
# TYPE teraslice_job_kafka_rebalance_total counter
teraslice_job_kafka_rebalance_total{op_name="kafka_reader",name="ts-dev1",url="",ex_id="2fd8e76d-e688-4e0a-8071-faf08eb29556",job_id="5fe83321-9318-4782-9927-1502231a50cb",job_name="j-kafka-test-kb-size",assignment="worker",pod_name="ts-wkr-j-kafka-test-kb-size-5fe83321-9318-67f86db7c5-2rpn8"} 2
```

Ref to issue #1147