### PR TITLE
Kafka verify fix

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "6.5.4",
+    "version": "6.5.5",
     "minimum_teraslice_version": "3.3.3"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "6.5.4",
+    "version": "6.5.5",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/asset/src/kafka_sender/processor.ts
+++ b/asset/src/kafka_sender/processor.ts
@@ -65,6 +65,7 @@ export default class KafkaSender extends BatchProcessor<KafkaSenderConfig> {
         );
 
         this.api = api;
+        await this.api.verify();
     }
 
     async onBatch(batch: DataEntity[]): Promise<DataEntity[]> {

--- a/asset/src/kafka_sender_api/sender.ts
+++ b/asset/src/kafka_sender_api/sender.ts
@@ -106,10 +106,6 @@ export default class KafkaSender implements RouteSenderAPI {
 
     async send(data: Iterable<DataEntity>): Promise<number> {
         const records = Array.isArray(data) ? data : Array.from(data);
-        if (this.config._op !== 'routed_sender') {
-            // routed_sender instead calls verify(route) for every record
-            await this.verify();
-        }
 
         await this.producer.produce(records, this.batchNumber, this.mapper);
         this.batchNumber++;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "6.5.4",
+    "version": "6.5.5",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",

--- a/test/kafka_sender/schema-spec.ts
+++ b/test/kafka_sender/schema-spec.ts
@@ -7,10 +7,12 @@ import { Logger } from '@terascope/core-utils';
 import { WorkerTestHarness } from 'teraslice-test-harness';
 import Connector from 'terafoundation_kafka_connector';
 import { connectorConfig } from '../helpers/config.js';
+import KafkaAdmin from '../helpers/kafka-admin.js';
 
 describe('Kafka Sender Schema', () => {
-    let harness: WorkerTestHarness;
     const connectionEndpoint = 'default';
+    const topic = 'hello';
+    let harness: WorkerTestHarness;
 
     const kafkaConfig: TestClientConfig = {
         type: 'kafka',
@@ -45,8 +47,16 @@ describe('Kafka Sender Schema', () => {
         await harness.initialize();
     }
 
+    const admin = new KafkaAdmin();
+
+    beforeAll(async () => admin.ensureTopic(topic));
+
     afterEach(async () => {
         if (harness) await harness.shutdown();
+    });
+
+    afterAll(async () => {
+        admin.disconnect();
     });
 
     describe('when validating the schema', () => {
@@ -59,7 +69,7 @@ describe('Kafka Sender Schema', () => {
         });
 
         it('should not throw an error if valid config is given', async () => {
-            const apiConfig = { _name: 'kafka_sender_api', topic: 'hello' };
+            const apiConfig = { _name: 'kafka_sender_api', topic };
             await expect(makeTest({
                 _op: 'kafka_sender',
                 _api_name: 'kafka_sender_api'

--- a/test/kafka_sender_api/sender-spec.ts
+++ b/test/kafka_sender_api/sender-spec.ts
@@ -146,24 +146,6 @@ describe('KafkaRouteSender', () => {
             .rejects.toThrow(`Topic ${topic}-nonexistent does not exist and could not be created.`);
     });
 
-    it('send calls verify for non-routed_sender operations', async () => {
-        const sender = await makeTest();
-        let verifyCalled = false;
-        const originalVerify = sender.verify.bind(sender);
-
-        sender.verify = async (route?: string): Promise<void> => {
-            verifyCalled = true;
-            // Mock doesTopicExist to return true so verify completes successfully
-            sender.producer.doesTopicExist = async (): Promise<boolean> => true;
-            return originalVerify(route);
-        };
-
-        const data = [DataEntity.make({ hello: 'world' })];
-        await sender.send(data);
-
-        expect(verifyCalled).toBe(true);
-    });
-
     it('send does not call verify when _op is routed_sender', async () => {
         const sender = await makeTest({ _op: 'routed_sender' });
         let verifyCalled = false;

--- a/test/kafka_sender_api/sender-spec.ts
+++ b/test/kafka_sender_api/sender-spec.ts
@@ -146,20 +146,6 @@ describe('KafkaRouteSender', () => {
             .rejects.toThrow(`Topic ${topic}-nonexistent does not exist and could not be created.`);
     });
 
-    it('send does not call verify when _op is routed_sender', async () => {
-        const sender = await makeTest({ _op: 'routed_sender' });
-        let verifyCalled = false;
-
-        sender.verify = async (): Promise<void> => {
-            verifyCalled = true;
-        };
-
-        const data = [DataEntity.make({ hello: 'world' })];
-        await sender.send(data);
-
-        expect(verifyCalled).toBe(false);
-    });
-
     describe('->getKey', () => {
         let sender: KafkaRouteSender;
 


### PR DESCRIPTION
- remove verify from inside the send function, this was causing failing when used with the routed sender fix. This api should have no knowledge of other operations. Moved the verify of the sender to the initialization of the kafka_sender op