### PR TITLE
[CI] pin github actions workflow to a specific commit

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -16,10 +16,10 @@ permissions:
 jobs:
   call-master-asset-build:
     if: github.event.pull_request.merged == true && github.base_ref == 'master'
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@main
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
     secrets: inherit
 
   call-prerelease-asset-build:
     if: github.event.pull_request.merged == true && startsWith(github.base_ref, 'release/kafka-assets-v')
-    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@main
+    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
     secrets: inherit

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-refresh-docker-cache-workflow:
-    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@main
+    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -10,5 +10,5 @@ on:
       - master
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@main
+    uses: terascope/workflows/.github/workflows/asset-test.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
     secrets: inherit

--- a/.github/workflows/test-prerelease-asset.yml
+++ b/.github/workflows/test-prerelease-asset.yml
@@ -11,5 +11,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@main
+    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
     secrets: inherit


### PR DESCRIPTION
This PR pins reusable workflows to a specific commit to improve security. It will also trigger the `build-and-publish-asset.yml` workflow to publish `terafoundation_kafka_connector` to NPM. It was not published in #1159 because of faulty workflow logic.