### PR TITLE
[CI] pin new workflows hash

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -16,10 +16,10 @@ permissions:
 jobs:
   call-master-asset-build:
     if: github.event.pull_request.merged == true && github.base_ref == 'master'
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit
 
   call-prerelease-asset-build:
     if: github.event.pull_request.merged == true && startsWith(github.base_ref, 'release/kafka-assets-v')
-    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
+    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-refresh-docker-cache-workflow:
-    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
+    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -10,5 +10,5 @@ on:
       - master
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
+    uses: terascope/workflows/.github/workflows/asset-test.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit

--- a/.github/workflows/test-prerelease-asset.yml
+++ b/.github/workflows/test-prerelease-asset.yml
@@ -11,5 +11,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@d5e76ceafa7682ffe4d2453ca9da301758f281a4
+    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit


### PR DESCRIPTION
This PR pins a new `@terascope/workflows` hash to fix a missing pnpm install in `check-version` job of publish workflows. See https://github.com/terascope/workflows/pull/63