### PR TITLE
Bump minimum_teraslice_version to 3.15.0

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka",
     "description": "Kafka reader and writer support.",
-    "version": "6.8.0",
+    "version": "6.9.0",
     "minimum_teraslice_version": "3.15.0"
 }

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -2,5 +2,5 @@
     "name": "kafka",
     "description": "Kafka reader and writer support.",
     "version": "6.8.0",
-    "minimum_teraslice_version": "3.3.3"
+    "minimum_teraslice_version": "3.15.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-assets",
     "displayName": "Asset",
-    "version": "6.8.0",
+    "version": "6.9.0",
     "private": true,
     "description": "Teraslice asset for kafka operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kafka-asset-bundle",
     "displayName": "Kafka Asset Bundle",
-    "version": "6.8.0",
+    "version": "6.9.0",
     "private": true,
     "description": "A bundle of Kafka operations and processors for Teraslice",
     "homepage": "https://github.com/terascope/kafka-assets",

--- a/packages/terafoundation_kafka_connector/package.json
+++ b/packages/terafoundation_kafka_connector/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation_kafka_connector",
     "displayName": "Terafoundation Kafka Connector",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "Terafoundation connector for Kafka producer and consumer clients.",
     "homepage": "https://github.com/terascope/kafka-assets",
     "repository": "git@github.com:terascope/kafka-assets.git",


### PR DESCRIPTION
This PR makes the following changes:

- Bumps `minimum_teraslice_version` from `v3.3.0` to `v3.15.0`
- Bumps Kafka Assets from `v6.8.0` to `v6.9.0`

ref to issue https://github.com/terascope/teraslice/issues/4509